### PR TITLE
fix: Make it so you can't pay yourself

### DIFF
--- a/commands/pay.py
+++ b/commands/pay.py
@@ -15,6 +15,8 @@ class Pay(commands.Cog):
     async def pay(self, ctx, targetMember : discord.Member = None, amount = None):
         if targetMember == None or amount == None:
             await ctx.send("Incorrect Usage, !pay <user> <amount>")
+        elif targetMember == ctx.author:
+            await ctx.send("Incorrect Usage, You may not pay yourself")
         else:
             amount = round(float(amount), 2) # Don't want people sending 0.33333... to people
             userBal = fetch_balance(ctx.author)


### PR DESCRIPTION
As of right now you can do

`!pay @MM-coder 1`

where @MM-coder is your discord user.

I added a simple check to disallow someone paying them self, even though it doesn't change their balance it is a unnecessary dB request