### PR TITLE
Move all commands out of single Cogs

### DIFF
--- a/commands/badge.py
+++ b/commands/badge.py
@@ -7,29 +7,24 @@ import utils.database as sql
 from utils.helpers import *
 
 
-class Badge(commands.Cog):
+@commands.command()
+async def badge(ctx, operation, badge, user : discord.Member):
+    message = ctx.message
+    if "Manager" in [role.name for role in message.author.roles]:
+        if operation.upper() == "ADD":
+            current_badges = get_profile(str(user.id))[3]
+            new_badges = current_badges + badge +" _ _"
+            sql.execute_query("UPDATE Members SET Badges = '%s' WHERE UserID = %s" % (new_badges.replace("'", "''"), str(user.id)))
+            await message.channel.send(":ok_hand: Successfully added %s to **%s**'s profile!" % (badge, user.name))
 
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command()
-    async def badge(self, ctx, operation, badge, user : discord.Member):
-        message = ctx.message
-        if "Manager" in [role.name for role in message.author.roles]:
-            if operation.upper() == "ADD":
-                current_badges = get_profile(str(user.id))[3]
-                new_badges = current_badges + badge +" _ _"
-                sql.execute_query("UPDATE Members SET Badges = '%s' WHERE UserID = %s" % (new_badges.replace("'", "''"), str(user.id)))
-                await message.channel.send(":ok_hand: Successfully added %s to **%s**'s profile!" % (badge, user.name))
-
-            if operation.upper() == "REMOVE":
-                badge = badge + " _ _"
-                current_badges = get_profile(str(user.id))[3]
-                new_badges = current_badges.replace(badge, '')
-                sql.execute_query("UPDATE Members SET Badges = '%s' WHERE UserID = %s" % (new_badges.replace("'", "''"), str(user.id)))
-                await message.channel.send(":ok_hand: Successfully removed %s from **%s**'s profile!" % (badge, user.name))
-        else:
-            await ctx.send("**Insufficient Permissions:** This command requires permission rank `MANAGER`")
+        if operation.upper() == "REMOVE":
+            badge = badge + " _ _"
+            current_badges = get_profile(str(user.id))[3]
+            new_badges = current_badges.replace(badge, '')
+            sql.execute_query("UPDATE Members SET Badges = '%s' WHERE UserID = %s" % (new_badges.replace("'", "''"), str(user.id)))
+            await message.channel.send(":ok_hand: Successfully removed %s from **%s**'s profile!" % (badge, user.name))
+    else:
+        await ctx.send("**Insufficient Permissions:** This command requires permission rank `MANAGER`")
 
 def setup(client):
-    client.add_cog(Badge(client))
+    client.add_command(badge)

--- a/commands/balance.py
+++ b/commands/balance.py
@@ -6,25 +6,21 @@ import utils.values as value
 import utils.database as sql
 from utils.helpers import *
 
-class Balance(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
+@commands.command(aliases=["bal", "money"])
+async def balance(ctx, target : discord.Member = None):
+    if target == None:
+        balance = get_profile(ctx.author.id)[0]
+        target = ctx.author
+    else:
+        balance = get_profile(target.id)[0]
+    embed = discord.Embed(description="%s currently has **$%s**!" % (target.mention, str(balance)), color=colour.primary)
+    embed.set_author(name="Balance")
+    await ctx.send(embed=embed)
 
-    @commands.command(aliases=["bal", "money"])
-    async def balance(self, ctx, target : discord.Member = None):
-        if target == None:
-            balance = get_profile(ctx.author.id)[0]
-            target = ctx.author
-        else:
-            balance = get_profile(target.id)[0]
-        embed = discord.Embed(description="%s currently has **$%s**!" % (target.mention, str(balance)), color=colour.primary)
-        embed.set_author(name="Balance")
-        await ctx.send(embed=embed)
-
-    @balance.error
-    async def on_balance_error(self, ctx, error):
-        await ctx.send("Something went wrong, did you provide a valid user?")
+@balance.error
+async def on_balance_error(ctx, error):
+    await ctx.send("Something went wrong, did you provide a valid user?")
 
 def setup(client):
-    client.add_cog(Balance(client))
+    client.add_command(balance)

--- a/commands/coinflip.py
+++ b/commands/coinflip.py
@@ -6,75 +6,70 @@ import utils.values as value
 import utils.database as sql
 from utils.helpers import *
 
-class Coinflip(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
-
+@commands.command(aliases=["cf"])
+async def coinflip(ctx, target : discord.Member = None, amount = None, side = "heads"):
     '''
       CoinFlip Command
 
       Usage: !coinflip [@user] [amount] [heads|tails]
       Permissions: None
     '''
-    @commands.command(aliases=["cf"])
-    async def coinflip(self, ctx, target : discord.Member = None, amount = None, side = "heads"):
+    async def flip_coin():
+        coinflip_string = "Flipping Coin."
+        embed = discord.Embed(description=coinflip_string, color=colour.primary)
+        embed.set_author(name="Coinflip")
+        coinflip_msg = await ctx.send(embed=embed)
+        await asyncio.sleep(0.5)
+        for i in range(1,3):
+            coinflip_string += "."
+            embed.description=coinflip_string
+            await coinflip_msg.edit(embed=embed)
+            await asyncio.sleep(0.5)
+        embed.description = "The coin landed on **" + coin_side + "**!"
+        await coinflip_msg.edit(embed=embed)
 
-        async def flip_coin():
-           coinflip_string = "Flipping Coin."
-           embed = discord.Embed(description=coinflip_string, color=colour.primary)
-           embed.set_author(name="Coinflip")
-           coinflip_msg = await ctx.send(embed=embed)
-           await asyncio.sleep(0.5)
-           for i in range(1,3):
-               coinflip_string += "."
-               embed.description=coinflip_string
-               await coinflip_msg.edit(embed=embed)
-               await asyncio.sleep(0.5)
-           embed.description = "The coin landed on **" + coin_side + "**!"
-           await coinflip_msg.edit(embed=embed)
+    if target == None:
+        # normal coinflip
+        coin_side = random.choice(["heads", "tails"])
+        await flip_coin()
 
-        if target == None:
-           # normal coinflip
-           coin_side = random.choice(["heads", "tails"])
-           await flip_coin()
-
-        elif amount == None or not side.lower() in ["heads", "tails"]:
-            await ctx.send("**Invalid Usage**: !coinflip [@user] [amount] [heads|tails]")
+    elif amount == None or not side.lower() in ["heads", "tails"]:
+        await ctx.send("**Invalid Usage**: !coinflip [@user] [amount] [heads|tails]")
+    else:
+        # fight to the death coinflip
+        if float(amount) < 0.10:
+            await ctx.send("**You must bet at least $0.10!**")
         else:
-            # fight to the death coinflip
-            if float(amount) < 0.10:
-                await ctx.send("**You must bet at least $0.10!**")
+            user_bal = fetch_balance(ctx.author)
+            target_bal = fetch_balance(target)
+            if user_bal < float(amount):
+                await ctx.send("**You do not have enough money for this, try a lower amount.**")
+            elif target_bal < float(amount):
+                await ctx.send("**The target does not have enough money for this, try a lower amount.**")
             else:
-                user_bal = fetch_balance(ctx.author)
-                target_bal = fetch_balance(target)
-                if user_bal < float(amount):
-                    await ctx.send("**You do not have enough money for this, try a lower amount.**")
-                elif target_bal < float(amount):
-                    await ctx.send("**The target does not have enough money for this, try a lower amount.**")
-                else:
-                    add_balance(ctx.author, -float(amount))
-                    await ctx.send("%s type !accept to accept a coinflip with %s (%s) for $%s" % (target.mention, ctx.author.mention, side, str(amount)))
+                add_balance(ctx.author, -float(amount))
+                await ctx.send("%s type !accept to accept a coinflip with %s (%s) for $%s" % (target.mention, ctx.author.mention, side, str(amount)))
 
-                    def check(msg):
-                        return msg.author == target and msg.content.upper() == "!ACCEPT"
-                    try:
-                        await self.client.wait_for('message', check=check, timeout=30)
-                    except asyncio.TimeoutError:
-                        await ctx.send("Target did not respond in time")
-                        add_balance(ctx.author, float(amount))
+                def check(msg):
+                    return msg.author == target and msg.content.upper() == "!ACCEPT"
+                try:
+                    await ctx.bot.wait_for('message', check=check, timeout=30)
+                except asyncio.TimeoutError:
+                    await ctx.send("Target did not respond in time")
+                    add_balance(ctx.author, float(amount))
+                else:
+                    add_balance(target, -float(amount))
+                    coin_side = random.choice(["heads", "tails"])
+                    await flip_coin()
+                    if coin_side == side.lower():
+                        # user wins
+                        add_balance(ctx.author, float(amount)*2)
+                        await ctx.send(ctx.author.mention + " Has Won $" + amount)
                     else:
-                        add_balance(target, -float(amount))
-                        coin_side = random.choice(["heads", "tails"])
-                        await flip_coin()
-                        if coin_side == side.lower():
-                            # user wins
-                            add_balance(ctx.author, float(amount)*2)
-                            await ctx.send(ctx.author.mention + " Has Won $" + amount)
-                        else:
-                            # target wins
-                            add_balance(target, float(amount)*2)
-                            await ctx.send(target.mention + " Has Won $" + amount)
+                        # target wins
+                        add_balance(target, float(amount)*2)
+                        await ctx.send(target.mention + " Has Won $" + amount)
 
 def setup(client):
-    client.add_cog(Coinflip(client))
+    client.add_command(coinflip)

--- a/commands/cookie.py
+++ b/commands/cookie.py
@@ -6,35 +6,31 @@ import utils.values as value
 import utils.database as sql
 from utils.helpers import *
 
-class Cookie(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
+@commands.command()
+async def cookie(ctx, target : discord.Member):
+    '''
+    Give someone a cookie
 
-    @commands.command()
-    async def cookie(self, ctx, target : discord.Member):
-        '''
-        Give someone a cookie
+    Required Permission: None
+    Required Arguments: Mention
 
-        Required Permission: None
-        Required Arguments: Mention
-
-        '''
-        bal = fetch_balance(ctx.author)
-        args = ctx.message.content.split(' ')
-        if bal >= 0.01:
-            add_balance(ctx.author, -0.01)
-            cookie_type = random.choice(["just gave you a chocolate chip cookie!", "just gave you a otis spunkmeyer cookie!", "just gave you a super sized cookie!", "just gave you a sainsburys taste the difference cookie!"])
-            embed = discord.Embed(description="Hey %s, %s %s" % (args[1], ctx.message.author.mention, cookie_type), color=colour.secondary)
-            embed.set_author(name="Cookie")
-            embed.set_thumbnail(url="https://upload.wikimedia.org/wikipedia/commons/thumb/0/03/Oxygen480-apps-preferences-web-browser-cookies.svg/1024px-Oxygen480-apps-preferences-web-browser-cookies.svg.png")
-            await ctx.message.channel.send(embed=embed)
-            if not target.id == ctx.author.id:
-                cookies_no = sql.db_query("SELECT cookiesReceived FROM Members WHERE UserID = %s" % (str(target.id)))[0][0]
-                cookies_no = cookies_no + 1
-                sql.execute_query("UPDATE Members SET cookiesReceived = %s WHERE UserID = %s" % (str(cookies_no), str(target.id)))
-        else:
-            await ctx.send("%s you do not have sufficient funds for this!" % (ctx.message.author.mention))
+    '''
+    bal = fetch_balance(ctx.author)
+    args = ctx.message.content.split(' ')
+    if bal >= 0.01:
+        add_balance(ctx.author, -0.01)
+        cookie_type = random.choice(["just gave you a chocolate chip cookie!", "just gave you a otis spunkmeyer cookie!", "just gave you a super sized cookie!", "just gave you a sainsburys taste the difference cookie!"])
+        embed = discord.Embed(description="Hey %s, %s %s" % (args[1], ctx.message.author.mention, cookie_type), color=colour.secondary)
+        embed.set_author(name="Cookie")
+        embed.set_thumbnail(url="https://upload.wikimedia.org/wikipedia/commons/thumb/0/03/Oxygen480-apps-preferences-web-browser-cookies.svg/1024px-Oxygen480-apps-preferences-web-browser-cookies.svg.png")
+        await ctx.message.channel.send(embed=embed)
+        if not target.id == ctx.author.id:
+            cookies_no = sql.db_query("SELECT cookiesReceived FROM Members WHERE UserID = %s" % (str(target.id)))[0][0]
+            cookies_no = cookies_no + 1
+            sql.execute_query("UPDATE Members SET cookiesReceived = %s WHERE UserID = %s" % (str(cookies_no), str(target.id)))
+    else:
+        await ctx.send("%s you do not have sufficient funds for this!" % (ctx.message.author.mention))
 
 def setup(client):
-    client.add_cog(Cookie(client))
+    client.add_command(cookie)

--- a/commands/cosmetics.py
+++ b/commands/cosmetics.py
@@ -6,106 +6,102 @@ import utils.values as value
 import utils.database as sql
 from utils.helpers import *
 
-class Cosmetics(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command(aliases=["cosmetic", "inventory"])
-    async def cosmetics(self, ctx, operand = None, *, cosmetic = None):
-        if operand is None:
-            #get inventory
-            cosmetics_all = sql.db_query("SELECT cosmetic_id FROM cosmetics")
-            cosmetics_total = len(cosmetics_all)
-            inventory = eval(sql.db_query("SELECT cosmetics FROM Members WHERE UserID = %s" % (str(ctx.author.id)))[0][0])
-            inventory_size = len(inventory)
-            if len(inventory) == 0:
-                embed = discord.Embed(title="Inventory", description="You have nothing in your inventory", color=reds)
-                await ctx.send(embed=embed)
-            else:
-                inventory_string = ""
-                count = 1
-                for item_id in inventory:
-                    cosmetic = sql.db_query("SELECT * from cosmetics WHERE cosmetic_id = %s" % (str(item_id)))[0]
-                    inventory_string += str(count) + ") **" + cosmetic[2] + "** " + cosmetic[1] +"\n"
-                    count = count + 1
-                embed = discord.Embed(title="Inventory", description=inventory_string, color=colour.secondary)
-                embed.set_footer(text="%s/%s Cosmetics Unlocked" % (str(inventory_size), str(cosmetics_total)))
-                await ctx.send(embed=embed)
-
-        elif operand.upper() == "SHOW" or operand.upper() == "DISPLAY":
-            index = int(cosmetic)
-            inventory = eval(sql.db_query("SELECT cosmetics FROM Members WHERE UserID = %s" % (str(ctx.author.id)))[0][0])
-            inventory_size = len(inventory)
-            try:
-                item_id = inventory[index-1]
-            except IndexError:
-                await ctx.send("**Error:** You do not own a cosmetic under that id")
-                return
-            item = sql.db_query("SELECT * from cosmetics WHERE cosmetic_id = %s" % (str(item_id)))[0]
-            if item[2] == "COMMON":
-                embed_color = 0xFFFFFF
-            elif item[2] == "UNCOMMON":
-                embed_color = 0x55FF55
-            elif item[2] == "RARE":
-                embed_color = 0X5555FF
-            elif item[2] == "LEGENDARY":
-                embed_color = 0xFFAA00
-            elif item[2] == "SPECIAL":
-                embed_color = 0xFF55FF
-            elif item[2] == "FESTIVE":
-                embed_color = 0x00AA00
-            embed = discord.Embed(title=item[1], description=item[3], color=embed_color)
-            embed.set_author(name=item[2])
-            if not item[4] is None:
-                embed.set_thumbnail(url=item[4])
-            embed.set_footer(text="Item Owned By: " + str(ctx.author))
+@commands.command(aliases=["cosmetic", "inventory"])
+async def cosmetics(ctx, operand = None, *, cosmetic = None):
+    if operand is None:
+        #get inventory
+        cosmetics_all = sql.db_query("SELECT cosmetic_id FROM cosmetics")
+        cosmetics_total = len(cosmetics_all)
+        inventory = eval(sql.db_query("SELECT cosmetics FROM Members WHERE UserID = %s" % (str(ctx.author.id)))[0][0])
+        inventory_size = len(inventory)
+        if len(inventory) == 0:
+            embed = discord.Embed(title="Inventory", description="You have nothing in your inventory", color=reds)
+            await ctx.send(embed=embed)
+        else:
+            inventory_string = ""
+            count = 1
+            for item_id in inventory:
+                cosmetic = sql.db_query("SELECT * from cosmetics WHERE cosmetic_id = %s" % (str(item_id)))[0]
+                inventory_string += str(count) + ") **" + cosmetic[2] + "** " + cosmetic[1] +"\n"
+                count = count + 1
+            embed = discord.Embed(title="Inventory", description=inventory_string, color=colour.secondary)
+            embed.set_footer(text="%s/%s Cosmetics Unlocked" % (str(inventory_size), str(cosmetics_total)))
             await ctx.send(embed=embed)
 
-        elif operand.upper() == "CREATE":
-            if "Manager" in [role.name for role in ctx.author.roles]:
-                cosmetic_args = "".join(cosmetic).split("|")
-                title = cosmetic_args[0]
-                rarity = cosmetic_args[1].upper()
-                description = cosmetic_args[2]
-                if len(cosmetic_args) >= 4:
-                    image_url = cosmetic_args[3]
-                else:
-                    image_url = None
-                if rarity == "COMMON":
-                    embed_color = 0xFFFFFF
-                elif rarity == "UNCOMMON":
-                    embed_color = 0x55FF55
-                elif rarity == "RARE":
-                    embed_color = 0X5555FF
-                elif rarity == "LEGENDARY":
-                    embed_color = 0xFFAA00
-                elif rarity == "SPECIAL":
-                    embed_color = 0xFF55FF
-                else:
-                    await ctx.send("**Error:** Invalid Rarity")
-                    return
-                embed = discord.Embed(title=title, description=description, color=embed_color)
-                embed.set_author(name=rarity)
-                if len(cosmetic_args) >= 4:
-                    embed.set_thumbnail(url=image_url)
+    elif operand.upper() == "SHOW" or operand.upper() == "DISPLAY":
+        index = int(cosmetic)
+        inventory = eval(sql.db_query("SELECT cosmetics FROM Members WHERE UserID = %s" % (str(ctx.author.id)))[0][0])
+        inventory_size = len(inventory)
+        try:
+            item_id = inventory[index-1]
+        except IndexError:
+            await ctx.send("**Error:** You do not own a cosmetic under that id")
+            return
+        item = sql.db_query("SELECT * from cosmetics WHERE cosmetic_id = %s" % (str(item_id)))[0]
+        if item[2] == "COMMON":
+            embed_color = 0xFFFFFF
+        elif item[2] == "UNCOMMON":
+            embed_color = 0x55FF55
+        elif item[2] == "RARE":
+            embed_color = 0X5555FF
+        elif item[2] == "LEGENDARY":
+            embed_color = 0xFFAA00
+        elif item[2] == "SPECIAL":
+            embed_color = 0xFF55FF
+        elif item[2] == "FESTIVE":
+            embed_color = 0x00AA00
+        embed = discord.Embed(title=item[1], description=item[3], color=embed_color)
+        embed.set_author(name=item[2])
+        if not item[4] is None:
+            embed.set_thumbnail(url=item[4])
+        embed.set_footer(text="Item Owned By: " + str(ctx.author))
+        await ctx.send(embed=embed)
 
-                await ctx.send(content="Confirm Creation Of Cosmetic (y/n)", embed=embed)
-                def check(m):
-                    return m.channel == ctx.message.channel and m.author == ctx.message.author
-                msg = await self.client.wait_for('message', check=check)
-                if msg.content.upper() == "Y":
-                    if image_url is None:
-                        sql.execute_query("INSERT INTO cosmetics (cosmetic_name, cosmetic_rarity, cosmetic_description) VALUES ('%s', '%s', '%s')" % (title.replace("'", "''"), rarity, description.replace("'", "''")))
-                    else:
-                        sql.execute_query("INSERT INTO cosmetics (cosmetic_name, cosmetic_rarity, cosmetic_description, cosmetic_image_url) VALUES ('%s', '%s', '%s', '%s')" % (title.replace("'", "''"), rarity, description.replace("'", "''"), image_url.replace("'", "''")))
-                    await ctx.send("Cosmetic Created")
-                else:
-                    await ctx.send("_Cancelled_")
+    elif operand.upper() == "CREATE":
+        if "Manager" in [role.name for role in ctx.author.roles]:
+            cosmetic_args = "".join(cosmetic).split("|")
+            title = cosmetic_args[0]
+            rarity = cosmetic_args[1].upper()
+            description = cosmetic_args[2]
+            if len(cosmetic_args) >= 4:
+                image_url = cosmetic_args[3]
             else:
-                await ctx.send("**Error:** Permission Denied. This command requires permission rank `MANAGER`")
+                image_url = None
+            if rarity == "COMMON":
+                embed_color = 0xFFFFFF
+            elif rarity == "UNCOMMON":
+                embed_color = 0x55FF55
+            elif rarity == "RARE":
+                embed_color = 0X5555FF
+            elif rarity == "LEGENDARY":
+                embed_color = 0xFFAA00
+            elif rarity == "SPECIAL":
+                embed_color = 0xFF55FF
+            else:
+                await ctx.send("**Error:** Invalid Rarity")
+                return
+            embed = discord.Embed(title=title, description=description, color=embed_color)
+            embed.set_author(name=rarity)
+            if len(cosmetic_args) >= 4:
+                embed.set_thumbnail(url=image_url)
+
+            await ctx.send(content="Confirm Creation Of Cosmetic (y/n)", embed=embed)
+            def check(m):
+                return m.channel == ctx.message.channel and m.author == ctx.message.author
+            msg = await ctx.bot.wait_for('message', check=check)
+            if msg.content.upper() == "Y":
+                if image_url is None:
+                    sql.execute_query("INSERT INTO cosmetics (cosmetic_name, cosmetic_rarity, cosmetic_description) VALUES ('%s', '%s', '%s')" % (title.replace("'", "''"), rarity, description.replace("'", "''")))
+                else:
+                    sql.execute_query("INSERT INTO cosmetics (cosmetic_name, cosmetic_rarity, cosmetic_description, cosmetic_image_url) VALUES ('%s', '%s', '%s', '%s')" % (title.replace("'", "''"), rarity, description.replace("'", "''"), image_url.replace("'", "''")))
+                await ctx.send("Cosmetic Created")
+            else:
+                await ctx.send("_Cancelled_")
         else:
-            await ctx.send("**Error:** Invalid Usage")
+            await ctx.send("**Error:** Permission Denied. This command requires permission rank `MANAGER`")
+    else:
+        await ctx.send("**Error:** Invalid Usage")
 
 def setup(client):
-    client.add_cog(Cosmetics(client))
+    client.add_command(cosmetics)

--- a/commands/crates.py
+++ b/commands/crates.py
@@ -7,83 +7,79 @@ import utils.database as sql
 from utils.helpers import *
 
 
-class Crates(commands.Cog):
+@commands.group(aliases=["loot", "crate"], invoke_without_command=True)
+async def crates(ctx):
+    crates_no = sql.db_query("SELECT crates FROM Members WHERE UserID = %s" % (str(ctx.author.id)))[0][0]
+    args = ctx.message.content.split(" ")
+    if len(args) == 1:
+        embed = discord.Embed(description="You currently have **%s** crate(s)" % (str(crates_no)),
+                              color=colour.reds)
+        embed.set_author(name="Crates")
+        await ctx.send(embed=embed)
 
-    def __init__(self, client):
-        self.client = client
 
-    @commands.group(aliases=["loot", "crate"], invoke_without_command=True)
-    async def crates(self, ctx):
-        crates_no = sql.db_query("SELECT crates FROM Members WHERE UserID = %s" % (str(ctx.author.id)))[0][0]
-        args = ctx.message.content.split(" ")
-        if len(args) == 1:
-            embed = discord.Embed(description="You currently have **%s** crate(s)" % (str(crates_no)),
-                                  color=colour.reds)
-            embed.set_author(name="Crates")
-            await ctx.send(embed=embed)
-
-    @crates.command(aliases=["use"])
-    async def open(self, ctx, amount: int = 1):
-        crates_no = sql.db_query("SELECT crates FROM Members WHERE UserID = %s" % (str(ctx.author.id)))[0][0]
-        if crates_no == 0:
-            await ctx.send("**Error:** You don't have any crates to open")
+@crates.command(aliases=["use"])
+async def open(ctx, amount: int = 1):
+    crates_no = sql.db_query("SELECT crates FROM Members WHERE UserID = %s" % (str(ctx.author.id)))[0][0]
+    if crates_no == 0:
+        await ctx.send("**Error:** You don't have any crates to open")
+    else:
+        if amount > 10:
+            await ctx.send(embed=discord.Embed(title="Crates Opening Error",
+                                               description="You're trying to open too many crates, try a smaller number.",
+                                               color=colour.reds))
+            return
+        elif amount <= 0:
+            await ctx.send(embed=discord.Embed(title="Crates Opening Error",
+                                               description="Please don't try to create a black hole and try a bigger number.",
+                                               color=colour.reds))
+            return
+        # If a user tries to open more crates than they have it'll default to how much they have
+        if crates_no < amount:
+            amount = crates_no
+        # Open crates
+        crates = [open_crate(ctx) for _ in range(0, amount)]
+        # Take however many crates the user opened
+        crates_no = crates_no - amount
+        sql.execute_query("UPDATE Members SET crates = %s WHERE UserID = %s" % (str(crates_no), str(ctx.author.id)))
+        embed = discord.Embed(description="Opening Crate" if amount == 1 else "Opening %d Crates" % amount)
+        embed.set_author(name="Crate")
+        msg = await ctx.send(embed=embed)
+        await asyncio.sleep(2)
+        if amount == 1:
+            print(crates)
+            embed = discord.Embed(title=crates[0][0], description=crates[0][1], color=crates[0][2])
+            embed.set_author(name=crates[0][3])
+            await msg.edit(embed=embed)
         else:
-            if amount > 10:
-                await ctx.send(embed=discord.Embed(title="Crates Opening Error",
-                                                   description="You're trying to open too many crates, try a smaller number.",
-                                                   color=colour.reds))
-                return
-            elif amount <= 0:
-                await ctx.send(embed=discord.Embed(title="Crates Opening Error",
-                                                   description="Please don't try to create a black hole and try a bigger number.",
-                                                   color=colour.reds))
-                return
-            # If a user tries to open more crates than they have it'll default to how much they have
-            if crates_no < amount:
-                amount = crates_no
-            # Open crates
-            crates = [open_crate(ctx) for _ in range(0, amount)]
-            # Take however many crates the user opened
-            crates_no = crates_no - amount
-            sql.execute_query("UPDATE Members SET crates = %s WHERE UserID = %s" % (str(crates_no), str(ctx.author.id)))
-            embed = discord.Embed(description="Opening Crate" if amount == 1 else "Opening %d Crates" % amount)
-            embed.set_author(name="Crate")
-            msg = await ctx.send(embed=embed)
-            await asyncio.sleep(2)
-            if amount == 1:
-                print(crates)
-                embed = discord.Embed(title=crates[0][0], description=crates[0][1], color=crates[0][2])
-                embed.set_author(name=crates[0][3])
-                await msg.edit(embed=embed)
-            else:
-                dupe_reward = 0
-                description = "You won:\n"
-                for c in crates:
-                    description += " - " + c[0].strip("You Won:").replace("(Duplicate)", "**(Duplicate +%d XP)**" % c[4])
-                    if "Duplicate" in c[0]:
-                        dupe_reward += c[4]
-                    description += "\n"
+            dupe_reward = 0
+            description = "You won:\n"
+            for c in crates:
+                description += " - " + c[0].strip("You Won:").replace("(Duplicate)", "**(Duplicate +%d XP)**" % c[4])
+                if "Duplicate" in c[0]:
+                    dupe_reward += c[4]
+                description += "\n"
 
-                if dupe_reward > 0:
-                    description += "\n"
-                    description += "You've earned **%d XP** from duplicates" % dupe_reward
-                embed = discord.Embed(title="You've successfully opened %d crates!" % amount,
-                                      description=description,
-                                      colour=colour.primary)
-                await msg.edit(embed=embed)
+            if dupe_reward > 0:
+                description += "\n"
+                description += "You've earned **%d XP** from duplicates" % dupe_reward
+            embed = discord.Embed(title="You've successfully opened %d crates!" % amount,
+                                  description=description,
+                                  colour=colour.primary)
+            await msg.edit(embed=embed)
 
-    @crates.command()
-    async def give(self, ctx, target: discord.Member = None, amount: int = 0):
-        if "Manager" in [role.name for role in ctx.message.author.roles]:
-            if target is not None:
-                crates_no = \
-                    sql.db_query("SELECT crates FROM Members WHERE UserID = %s" % (str(target.id)))[0][0]
-                crates_no = crates_no + amount
-                sql.execute_query("UPDATE Members SET crates = %s WHERE UserID = %s" % (
-                    str(crates_no), str(target.id)))
-                await ctx.send("Successfully gave %s **%s** crate(s)" % (target.mention, str(amount)))
-        else:
-            await ctx.send("**Insufficient Permissions:** This command requires permission rank `MANAGER`")
+@crates.command()
+async def give(ctx, target: discord.Member = None, amount: int = 0):
+    if "Manager" in [role.name for role in ctx.message.author.roles]:
+        if target is not None:
+            crates_no = \
+                sql.db_query("SELECT crates FROM Members WHERE UserID = %s" % (str(target.id)))[0][0]
+            crates_no = crates_no + amount
+            sql.execute_query("UPDATE Members SET crates = %s WHERE UserID = %s" % (
+                str(crates_no), str(target.id)))
+            await ctx.send("Successfully gave %s **%s** crate(s)" % (target.mention, str(amount)))
+    else:
+        await ctx.send("**Insufficient Permissions:** This command requires permission rank `MANAGER`")
 
 def open_crate(ctx):
     # Pick rarity
@@ -132,4 +128,4 @@ def open_crate(ctx):
     return title, description, embed_color, rarity, dupe_reward  # In this order to prevent confusion with indexes at the embed creation
 
 def setup(client):
-    client.add_cog(Crates(client))
+    client.add_command(crates)

--- a/commands/daily.py
+++ b/commands/daily.py
@@ -8,88 +8,83 @@ from utils.helpers import *
 import time
 
 
-class Daily(commands.Cog):
-
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command()
-    async def daily(self, ctx):
+@commands.command()
+async def daily(ctx):
         
-        def update_cooldown_and_streaks():
-            next_daily =  current_time + ((60 * 60) * 20)
-            sql.execute_query("UPDATE Members SET dailyRewardClaimed = %s WHERE UserID = %s " % (str(next_daily), str(ctx.author.id)))
-            new_streak = streak + 1
-            sql.execute_query("UPDATE Members SET dailyRewardStreak = %s WHERE UserID = %s " % (str(new_streak), str(ctx.author.id)))
+    def update_cooldown_and_streaks():
+        next_daily =  current_time + ((60 * 60) * 20)
+        sql.execute_query("UPDATE Members SET dailyRewardClaimed = %s WHERE UserID = %s " % (str(next_daily), str(ctx.author.id)))
+        new_streak = streak + 1
+        sql.execute_query("UPDATE Members SET dailyRewardStreak = %s WHERE UserID = %s " % (str(new_streak), str(ctx.author.id)))
          
-        current_time = time.time()
-        query = sql.db_query("SELECT dailyRewardClaimed, dailyRewardStreak FROM Members WHERE UserID = %s " % (str(ctx.author.id)))
-        last_advent = query[0][0]
-        streak = query[0][1]
-        if last_advent < current_time:
-            if current_time - last_advent > ((60*60)*24):
-                streak = 0
-                sql.execute_query("UPDATE Members SET dailyRewardStreak = %s WHERE UserID = %s " % (str(streak), str(ctx.author.id)))
+    current_time = time.time()
+    query = sql.db_query("SELECT dailyRewardClaimed, dailyRewardStreak FROM Members WHERE UserID = %s " % (str(ctx.author.id)))
+    last_advent = query[0][0]
+    streak = query[0][1]
+    if last_advent < current_time:
+        if current_time - last_advent > ((60*60)*24):
+            streak = 0
+            sql.execute_query("UPDATE Members SET dailyRewardStreak = %s WHERE UserID = %s " % (str(streak), str(ctx.author.id)))
 
-        if "Supporter" in [role.name for role in ctx.author.roles]:
-            multiplier = 1.25
+    if "Supporter" in [role.name for role in ctx.author.roles]:
+        multiplier = 1.25
+    else:
+        multiplier = 1
+
+    if last_advent < current_time:
+        cookie_chance = random.randint(1,25)
+        embed=discord.Embed(description="Select your reward by typing the number in chat", color=colour.primary)
+        embed.set_author(name="Daily Rewards")
+        embed.add_field(name="Reward 1", value=str(round(1000 + (streak * 5)*multiplier,0)) + " Exp", inline=False)
+        embed.add_field(name="Reward 2", value="$" + str(round(0.50 + (streak * 0.01)*multiplier,2)), inline=False)
+        if cookie_chance == 1:
+            embed.add_field(name="Reward 3", value="3 Cookies", inline=False)
+
+        embed.set_footer(text="Your current reward streak is: " + str(streak))
+        mssg = await ctx.send(embed=embed)
+        channel = ctx.channel
+
+        def check(m):
+            return m.author.id == ctx.author.id and m.channel == channel
+
+        try:
+            msg = await ctx.bot.wait_for('message', check=check, timeout=60.0)
+        except asyncio.TimeoutError:
+            embed = discord.Embed(description="No Message Received", color=colour.reds)
+            embed.set_author(name="Daily Reward")
+            await mssg.edit(embed=embed)
         else:
-            multiplier = 1
-
-        if last_advent < current_time:
-            cookie_chance = random.randint(1,25)
-            embed=discord.Embed(description="Select your reward by typing the number in chat", color=colour.primary)
-            embed.set_author(name="Daily Rewards")
-            embed.add_field(name="Reward 1", value=str(round(1000 + (streak * 5)*multiplier,0)) + " Exp", inline=False)
-            embed.add_field(name="Reward 2", value="$" + str(round(0.50 + (streak * 0.01)*multiplier,2)), inline=False)
-            if cookie_chance == 1:
-                embed.add_field(name="Reward 3", value="3 Cookies", inline=False)
-
-            embed.set_footer(text="Your current reward streak is: " + str(streak))
-            mssg = await ctx.send(embed=embed)
-            channel = ctx.channel
-
-            def check(m):
-                return m.author.id == ctx.author.id and m.channel == channel
-
-            try:
-                msg = await self.client.wait_for('message', check=check, timeout=60.0)
-            except asyncio.TimeoutError:
-                embed = discord.Embed(description="No Message Received", color=colour.reds)
+            await msg.delete()
+            if msg.content == "1":
+                add_exp(ctx.author.id, round(1000 + (streak * 10)*multiplier,0))
+                embed = discord.Embed(description="You unlocked **" + str(round(1000 + (streak * 5)*multiplier,0)) + " EXP**!", color=colour.primary)
                 embed.set_author(name="Daily Reward")
                 await mssg.edit(embed=embed)
+                update_cooldown_and_streaks()
+            elif msg.content == "2":
+                add_balance(ctx.author, round(0.10 + (streak * 0.01),2)*multiplier)
+                embed = discord.Embed(description="You unlocked **$" + str(round(0.50 + (streak * 0.01),2)*multiplier) + " **!", color=colour.primary)
+                embed.set_author(name="Daily Reward")
+                await mssg.edit(embed=embed)
+                update_cooldown_and_streaks()
+            elif msg.content == "3" and cookie_chance == 1:
+                embed = discord.Embed(description="You unlocked **3 Cookies**!", color=colour.primary)
+                embed.set_author(name="Daily Reward")
+                await mssg.edit(embed=embed)
+                cookies_no = sql.db_query("SELECT cookiesReceived FROM Members WHERE UserID = %s" % (str(ctx.author.id)))[0][0]
+                cookies_no = cookies_no + 3
+                sql.execute_query("UPDATE Members SET cookiesReceived = %s WHERE UserID = %s" % (str(cookies_no), str(ctx.author.id)))
+                update_cooldown_and_streaks()
             else:
-                await msg.delete()
-                if msg.content == "1":
-                    add_exp(ctx.author.id, round(1000 + (streak * 10)*multiplier,0))
-                    embed = discord.Embed(description="You unlocked **" + str(round(1000 + (streak * 5)*multiplier,0)) + " EXP**!", color=colour.primary)
-                    embed.set_author(name="Daily Reward")
-                    await mssg.edit(embed=embed)
-                    update_cooldown_and_streaks()
-                elif msg.content == "2":
-                    add_balance(ctx.author, round(0.10 + (streak * 0.01),2)*multiplier)
-                    embed = discord.Embed(description="You unlocked **$" + str(round(0.50 + (streak * 0.01),2)*multiplier) + " **!", color=colour.primary)
-                    embed.set_author(name="Daily Reward")
-                    await mssg.edit(embed=embed)
-                    update_cooldown_and_streaks()
-                elif msg.content == "3" and cookie_chance == 1:
-                    embed = discord.Embed(description="You unlocked **3 Cookies**!", color=colour.primary)
-                    embed.set_author(name="Daily Reward")
-                    await mssg.edit(embed=embed)
-                    cookies_no = sql.db_query("SELECT cookiesReceived FROM Members WHERE UserID = %s" % (str(ctx.author.id)))[0][0]
-                    cookies_no = cookies_no + 3
-                    sql.execute_query("UPDATE Members SET cookiesReceived = %s WHERE UserID = %s" % (str(cookies_no), str(ctx.author.id)))
-                    update_cooldown_and_streaks()
-                else:
-                    embed = discord.Embed(description="Invalid Response", color=colour.reds)
-                    embed.set_author(name="Daily Reward")
-                    await mssg.edit(embed=embed)
-        else:
-            next_advent = last_advent
-            time_difference = next_advent - current_time
-            time_difference_string = time_phaser(time_difference)
-            embed = discord.Embed(title="Error", description="You cannot use that command for another **%s**" % (time_difference_string), color=colour.reds)
-            await ctx.send(embed=embed)
+                embed = discord.Embed(description="Invalid Response", color=colour.reds)
+                embed.set_author(name="Daily Reward")
+                await mssg.edit(embed=embed)
+    else:
+        next_advent = last_advent
+        time_difference = next_advent - current_time
+        time_difference_string = time_phaser(time_difference)
+        embed = discord.Embed(title="Error", description="You cannot use that command for another **%s**" % (time_difference_string), color=colour.reds)
+        await ctx.send(embed=embed)
 
 def setup(client):
-    client.add_cog(Daily(client))
+    client.add_command(daily)

--- a/commands/economy.py
+++ b/commands/economy.py
@@ -6,32 +6,28 @@ import utils.values as value
 import utils.database as sql
 from utils.helpers import *
 
-class Economy(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command(aliases=["eco"])
-    async def economy(self, ctx, targetMember : discord.Member = None):
-        if "Manager" in [role.name for role in ctx.author.roles]:
-            args = ctx.message.content.split()
-            try:
-                action = args[2] #give, take, set
-                value = args[3]
-            except IndexError:
-                await ctx.send("Incorrect Usage, !economy <user> <give|take|set> <amount>")
-            if action.upper() == "GIVE":
-                add_balance(targetMember, float(value))
-                await ctx.send("Success! Added %s to **%s**'s balance" % (value, targetMember.name))
-            elif action.upper() == "TAKE":
-                add_balance(targetMember, -float(value))
-                await ctx.send("Success! Removed %s from **%s**'s balance" % (value, targetMember.name))
-            elif action.upper() == "SET":
-                set_balance(targetMember, float(value))
-                await ctx.send("Success! Set **%s**'s balance to %s" % (targetMember.name, value))
-        else:
-            await ctx.send("**Insufficient Permissions:** This command requires permission rank `MANAGER`")
+@commands.command(aliases=["eco"])
+async def economy(ctx, targetMember : discord.Member = None):
+    if "Manager" in [role.name for role in ctx.author.roles]:
+        args = ctx.message.content.split()
+        try:
+            action = args[2] #give, take, set
+            value = args[3]
+        except IndexError:
+            await ctx.send("Incorrect Usage, !economy <user> <give|take|set> <amount>")
+        if action.upper() == "GIVE":
+            add_balance(targetMember, float(value))
+            await ctx.send("Success! Added %s to **%s**'s balance" % (value, targetMember.name))
+        elif action.upper() == "TAKE":
+            add_balance(targetMember, -float(value))
+            await ctx.send("Success! Removed %s from **%s**'s balance" % (value, targetMember.name))
+        elif action.upper() == "SET":
+            set_balance(targetMember, float(value))
+            await ctx.send("Success! Set **%s**'s balance to %s" % (targetMember.name, value))
+    else:
+        await ctx.send("**Insufficient Permissions:** This command requires permission rank `MANAGER`")
 
 
 def setup(client):
-    client.add_cog(Economy(client))
+    client.add_command(economy)

--- a/commands/fight.py
+++ b/commands/fight.py
@@ -6,49 +6,45 @@ import utils.values as value
 import utils.database as sql
 from utils.helpers import *
 
-class Fight(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command()
-    async def fight(self, ctx):
-        bal = fetch_balance(ctx.author)
-        if bal >= 0.05:
-            add_balance(ctx.author, -0.05)
-            message = ctx.message
-            args = message.content.split()
-            loss = 0
-            rounds = 1
-            init = message.author.mention
-            target = " ".join(args[1:])
-            fight = "%s has challenged %s to a fight!" % (init, target) + "\n"
+@commands.command()
+async def fight(ctx):
+    bal = fetch_balance(ctx.author)
+    if bal >= 0.05:
+        add_balance(ctx.author, -0.05)
+        message = ctx.message
+        args = message.content.split()
+        loss = 0
+        rounds = 1
+        init = message.author.mention
+        target = " ".join(args[1:])
+        fight = "%s has challenged %s to a fight!" % (init, target) + "\n"
+        fightEm = discord.Embed(description=fight, colour=colour.reds)
+        fightEm.set_author(name="Fight")
+        fMessage = await message.channel.send(embed=fightEm)
+        while not (loss == 1) and not (rounds > 7):
+            fight = fight + random.choice(["%s threw a chair at %s" % (init, target), "%s whacked %s with a stick" % (init, target), "%s slapped %s to the floor" % (init, target), "%s threw %s through a wall" % (init, target), "%s bitch slapped %s" % (init, target), "%s used dark magic against %s" % (init, target), "%s used the infinity gauntlet" % (init), "%s used fake news on %s" % (init, target), "%s ran %s over with a truck" % (init, target), "%s ate %s and threw them up again" % (init, target), "%s savagely roasted %s for sunday lunch" % (init, target), "%s forced %s to watch anime" % (init, target), "%s slapped %s with a Macbook" % (init, target), "%s used TUNNELBEAR! THE FREE EASY TO USE VPN..." % (init), "%s performed a windows update on %s" % (init, target), "%s used the might of Zeus" % (init), "%s trapped %s in Flex Tape" % (init, target), "%s built a wall!" % (init)])+"\n"
+            fightEm = discord.Embed(title="Fight!", description=fight, colour=colour.reds)
+            await fMessage.edit(embed=fightEm)
+            await asyncio.sleep(2)
+            loss = random.randint(1, 4)
+            if loss == 1:
+                fight = fight + "%s accepts defeat! %s has won the fight!" % (target, init)
+            elif rounds == 7:
+                fight = fight + "The fight has ended in a draw!"
+            else:
+                fight = fight +"%s does not giveup and continues the fight!" % (target) + "\n"
             fightEm = discord.Embed(description=fight, colour=colour.reds)
             fightEm.set_author(name="Fight")
-            fMessage = await message.channel.send(embed=fightEm)
-            while not (loss == 1) and not (rounds > 7):
-                fight = fight + random.choice(["%s threw a chair at %s" % (init, target), "%s whacked %s with a stick" % (init, target), "%s slapped %s to the floor" % (init, target), "%s threw %s through a wall" % (init, target), "%s bitch slapped %s" % (init, target), "%s used dark magic against %s" % (init, target), "%s used the infinity gauntlet" % (init), "%s used fake news on %s" % (init, target), "%s ran %s over with a truck" % (init, target), "%s ate %s and threw them up again" % (init, target), "%s savagely roasted %s for sunday lunch" % (init, target), "%s forced %s to watch anime" % (init, target), "%s slapped %s with a Macbook" % (init, target), "%s used TUNNELBEAR! THE FREE EASY TO USE VPN..." % (init), "%s performed a windows update on %s" % (init, target), "%s used the might of Zeus" % (init), "%s trapped %s in Flex Tape" % (init, target), "%s built a wall!" % (init)])+"\n"
-                fightEm = discord.Embed(title="Fight!", description=fight, colour=colour.reds)
-                await fMessage.edit(embed=fightEm)
-                await asyncio.sleep(2)
-                loss = random.randint(1, 4)
-                if loss == 1:
-                    fight = fight + "%s accepts defeat! %s has won the fight!" % (target, init)
-                elif rounds == 7:
-                    fight = fight + "The fight has ended in a draw!"
-                else:
-                    fight = fight +"%s does not giveup and continues the fight!" % (target) + "\n"
-                fightEm = discord.Embed(description=fight, colour=colour.reds)
-                fightEm.set_author(name="Fight")
-                await fMessage.edit(embed=fightEm)
-                temp = target
-                target = init
-                init = temp
-                rounds = rounds + 1
-                await asyncio.sleep(4)
-        else:
-            await ctx.send("%s you do not have sufficient funds for this!" % (ctx.message.author.mention))
+            await fMessage.edit(embed=fightEm)
+            temp = target
+            target = init
+            init = temp
+            rounds = rounds + 1
+            await asyncio.sleep(4)
+    else:
+        await ctx.send("%s you do not have sufficient funds for this!" % (ctx.message.author.mention))
 
 
 def setup(client):
-    client.add_cog(Fight(client))
+    client.add_command(fight)

--- a/commands/help.py
+++ b/commands/help.py
@@ -6,21 +6,17 @@ import utils.values as value
 import utils.database as sql
 from utils.helpers import *
 
-class Help(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command()
-    async def help(self, ctx):
-        helpEm = discord.Embed(description="", color=colour.primary)
-        helpEm.set_author(name="Command Help")
-        helpEm.set_thumbnail(url="https://i.foggyio.uk/varsity_discord.png")
-        helpEm.add_field(name="User Commands", value="**!daily**\n**!profile** [user]\n**!playing**\n**!coinflip**\n**!ransack** <user> <amount>\n**!ping**\n**!cookie** <user>\n**!hug** <user>\n**!tag** <tag name | create>\n**!streaks**\n**!leaderboard**\n**!weekly**\n**!shop** [buy] [item]\n**!kitten**\n**!puppy**\n**!cosmetics** [show] <id>\n**!crates** [open]\n**!pay** <user> <amount>", inline=False)
-        helpEm.add_field(name="Supporter Commands", value="**!poll** <time> <question>|<option1>|<option2>|...", inline=False)
-        if "Moderator" in [role.name for role in ctx.message.author.roles] or "Manager" in [role.name for role in ctx.message.author.roles]:
-            helpEm.add_field(name="Administration Commands", value="**!unload** <module>\n**!load** <module>\n**!reload** <module>\n**!multiplier** <amount>\n**!economy** <user> <give| take | set> <amount>\n**!badge** <add | remove> <emoji> <user>\n**!xp** <user> give [amount]\n**!raffle** <time> <item>")
-        await ctx.message.channel.send(embed=helpEm)
+@commands.command()
+async def help_(ctx):
+    helpEm = discord.Embed(description="", color=colour.primary)
+    helpEm.set_author(name="Command Help")
+    helpEm.set_thumbnail(url="https://i.foggyio.uk/varsity_discord.png")
+    helpEm.add_field(name="User Commands", value="**!daily**\n**!profile** [user]\n**!playing**\n**!coinflip**\n**!ransack** <user> <amount>\n**!ping**\n**!cookie** <user>\n**!hug** <user>\n**!tag** <tag name | create>\n**!streaks**\n**!leaderboard**\n**!weekly**\n**!shop** [buy] [item]\n**!kitten**\n**!puppy**\n**!cosmetics** [show] <id>\n**!crates** [open]\n**!pay** <user> <amount>", inline=False)
+    helpEm.add_field(name="Supporter Commands", value="**!poll** <time> <question>|<option1>|<option2>|...", inline=False)
+    if "Moderator" in [role.name for role in ctx.message.author.roles] or "Manager" in [role.name for role in ctx.message.author.roles]:
+        helpEm.add_field(name="Administration Commands", value="**!unload** <module>\n**!load** <module>\n**!reload** <module>\n**!multiplier** <amount>\n**!economy** <user> <give| take | set> <amount>\n**!badge** <add | remove> <emoji> <user>\n**!xp** <user> give [amount]\n**!raffle** <time> <item>")
+    await ctx.message.channel.send(embed=helpEm)
 
 def setup(client):
-    client.add_cog(Help(client))
+    client.add_command(help_)

--- a/commands/hug.py
+++ b/commands/hug.py
@@ -6,30 +6,26 @@ import utils.values as value
 import utils.database as sql
 from utils.helpers import *
 
-class Hug(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
+@commands.command()
+async def hug(ctx):
+    '''
+    Hug Someone
 
-    @commands.command()
-    async def hug(self, ctx):
-        '''
-        Hug Someone
+    Required Permission: @Outstandingly Regular
+    Required Arguments: Mention
 
-        Required Permission: @Outstandingly Regular
-        Required Arguments: Mention
-
-        '''
-        bal = fetch_balance(ctx.author)
-        if bal >= 0.01:
-            add_balance(ctx.author, -0.01)
-            args = ctx.message.content.split()
-            hug_type = random.choice(["just gave you a big hug!", "just gave you a big big hug!", "just gave you a tight squeeze!", "just gave you a cute hug!"])
-            embed = discord.Embed(description="Hey %s, %s %s" % (args[1], ctx.message.author.mention, hug_type), color=colour.secondary)
-            embed.set_author(name="Hug")
-            await ctx.message.channel.send(embed=embed)
-        else:
-            await ctx.send("%s you do not have sufficient funds for this!" % (ctx.message.author.mention))
+    '''
+    bal = fetch_balance(ctx.author)
+    if bal >= 0.01:
+        add_balance(ctx.author, -0.01)
+        args = ctx.message.content.split()
+        hug_type = random.choice(["just gave you a big hug!", "just gave you a big big hug!", "just gave you a tight squeeze!", "just gave you a cute hug!"])
+        embed = discord.Embed(description="Hey %s, %s %s" % (args[1], ctx.message.author.mention, hug_type), color=colour.secondary)
+        embed.set_author(name="Hug")
+        await ctx.message.channel.send(embed=embed)
+    else:
+        await ctx.send("%s you do not have sufficient funds for this!" % (ctx.message.author.mention))
 
 def setup(client):
-    client.add_cog(Hug(client))
+    client.add_command(hug)

--- a/commands/kitten.py
+++ b/commands/kitten.py
@@ -7,17 +7,13 @@ import utils.database as sql
 from utils.helpers import *
 import requests
 
-class Kitten(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command()
-    async def kitten(self, ctx):
-        imgUrl = requests.get('https://api.thecatapi.com/v1/images/search').json()[0]['url']
-        em = discord.Embed(title="Kitten", image=imgUrl, colour=colour.secondary)
-        em.set_image(url=imgUrl)
-        await ctx.send(embed=em)
+@commands.command()
+async def kitten(ctx):
+    imgUrl = requests.get('https://api.thecatapi.com/v1/images/search').json()[0]['url']
+    em = discord.Embed(title="Kitten", image=imgUrl, colour=colour.secondary)
+    em.set_image(url=imgUrl)
+    await ctx.send(embed=em)
 
 def setup(client):
-    client.add_cog(Kitten(client))
+    client.add_command(kitten)

--- a/commands/leaderboard.py
+++ b/commands/leaderboard.py
@@ -8,14 +8,10 @@ import utils.database as sql
 import math
 from utils.helpers import *
 
-class Leaderboard(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command(aliases=["lb", "lboard", "topusers", "top"])
-    async def leaderboard(self, ctx):
-        await leaderboard_main(ctx, self=self)
+@commands.command(aliases=["lb", "lboard", "topusers", "top"])
+async def leaderboard(ctx):
+    await leaderboard_main(ctx)
 
 def generate_leaderboard_string(guild, page=1):
     leaderboard_2d_array = sql.db_query("SELECT UserID, Level, expTotal FROM Members WHERE NOT UserID = 1 ORDER BY expTotal DESC")
@@ -37,7 +33,7 @@ def generate_leaderboard_string(guild, page=1):
             break
     return leaderboard_string
 
-async def leaderboard_main(ctx, page=1, leaderboard_message_object=None, self=None):
+async def leaderboard_main(ctx, page=1, leaderboard_message_object=None):
     max_pages = math.ceil((len(ctx.guild.members)-2)/10)
     leaderboard_string = generate_leaderboard_string(ctx.guild, page)
     embed = discord.Embed(description=leaderboard_string, color=colour.primary)
@@ -54,22 +50,22 @@ async def leaderboard_main(ctx, page=1, leaderboard_message_object=None, self=No
         return user == ctx.author and (str(reaction.emoji) == "◀" or str(reaction.emoji) == "▶")
 
     try:
-        reaction, user = await self.client.wait_for('reaction_add', timeout=30.0, check=check)
+        reaction, user = await ctx.bot.wait_for('reaction_add', timeout=30.0, check=check)
     except asyncio.TimeoutError:
         await leaderboard_message_object.clear_reactions()
     else:
         await reaction.remove(user)
         if str(reaction.emoji) == "◀":
             if not page == 1:
-                await leaderboard_main(ctx, page-1, leaderboard_message_object, self=self)
+                await leaderboard_main(ctx, page-1, leaderboard_message_object)
             else:
-                await leaderboard_main(ctx, page, leaderboard_message_object, self=self)
+                await leaderboard_main(ctx, page, leaderboard_message_object)
 
         elif str(reaction.emoji) == "▶":
             if not page+1 > max_pages:
-                await leaderboard_main(ctx, page+1, leaderboard_message_object, self=self)
+                await leaderboard_main(ctx, page+1, leaderboard_message_object)
             else:
-                await leaderboard_main(ctx, page, leaderboard_message_object, self=self)
+                await leaderboard_main(ctx, page, leaderboard_message_object)
 
 def setup(client):
-    client.add_cog(Leaderboard(client))
+    client.add_command(leaderboard)

--- a/commands/may.py
+++ b/commands/may.py
@@ -6,15 +6,11 @@ import utils.values as value
 import utils.database as sql
 from utils.helpers import *
 
-class May(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command()
-    async def may(self, ctx):
-        quote = random.choice(["The Government cannot just be consumed by Brexit. There is so much more to do", "My whole philosophy is about doing, not talking.", "I actually think I think better in high heels", "I've been clear that Brexit means Brexit", "I think we all agree that the comments Donald Trump made in relation to Muslims were divisive, unhelpful and wrong.", "There must be no attempts to remain inside the E.U., no attempts to rejoin it through the back door, and no second referendum.", "Strong and Stable leadership"])
-        await ctx.send(quote)
+@commands.command()
+async def may(ctx):
+    quote = random.choice(["The Government cannot just be consumed by Brexit. There is so much more to do", "My whole philosophy is about doing, not talking.", "I actually think I think better in high heels", "I've been clear that Brexit means Brexit", "I think we all agree that the comments Donald Trump made in relation to Muslims were divisive, unhelpful and wrong.", "There must be no attempts to remain inside the E.U., no attempts to rejoin it through the back door, and no second referendum.", "Strong and Stable leadership"])
+    await ctx.send(quote)
 
 def setup(client):
-    client.add_cog(May(client))
+    client.add_command(may)

--- a/commands/multiplier.py
+++ b/commands/multiplier.py
@@ -7,21 +7,16 @@ import utils.database as sql
 from utils.helpers import *
 
 
-class Multiplier(commands.Cog):
-
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command()
-    async def multiplier(self, ctx):
-        if "Manager" in [role.name for role in ctx.message.author.roles]:
-            args = ctx.message.content.split(" ")
-            multiplier = int(args[1])
-            level_up(1, multiplier)
-            await ctx.message.channel.send(":ok_hand: Successfully set exp multiplier to %s" % (args[1]))
-        else:
-            await ctx.send("**Insufficient Permissions:** This command requires permission rank `MANAGER`")
+@commands.command()
+async def multiplier(ctx):
+    if "Manager" in [role.name for role in ctx.message.author.roles]:
+        args = ctx.message.content.split(" ")
+        multiplier = int(args[1])
+        level_up(1, multiplier)
+        await ctx.message.channel.send(":ok_hand: Successfully set exp multiplier to %s" % (args[1]))
+    else:
+        await ctx.send("**Insufficient Permissions:** This command requires permission rank `MANAGER`")
 
 
 def setup(client):
-    client.add_cog(Multiplier(client))
+    client.add_command(multiplier)

--- a/commands/pay.py
+++ b/commands/pay.py
@@ -6,35 +6,31 @@ import utils.values as value
 import utils.database as sql
 from utils.helpers import *
 
-class Pay(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command(aliases=["transfer"])
-    async def pay(self, ctx, targetMember : discord.Member = None, amount = None):
-        if targetMember == None or amount == None:
-            await ctx.send("Incorrect Usage, !pay <user> <amount>")
-        elif targetMember == ctx.author:
-            await ctx.send("Incorrect Usage, You may not pay yourself")
+@commands.command(aliases=["transfer"])
+async def pay(ctx, targetMember : discord.Member = None, amount = None):
+    if targetMember == None or amount == None:
+        await ctx.send("Incorrect Usage, !pay <user> <amount>")
+    elif targetMember == ctx.author:
+        await ctx.send("Incorrect Usage, You may not pay yourself")
+    else:
+        amount = round(float(amount), 2) # Don't want people sending 0.33333... to people
+        userBal = fetch_balance(ctx.author)
+        targetBal = fetch_balance(targetMember)
+        if float(amount) > userBal:
+            await ctx.send("You have insufficient funds for this")
+        elif float(amount) < 0.01:
+            await ctx.send("You need to send at least 0.01.")
         else:
-            amount = round(float(amount), 2) # Don't want people sending 0.33333... to people
-            userBal = fetch_balance(ctx.author)
-            targetBal = fetch_balance(targetMember)
-            if float(amount) > userBal:
-                await ctx.send("You have insufficient funds for this")
-            elif float(amount) < 0.01:
-                await ctx.send("You need to send at least 0.01.")
-            else:
-                try: # Begin Transaction
-                    add_balance(ctx.author, -float(amount))
-                    add_balance(targetMember, float(amount))
-                    await ctx.send("Transaction Complete!")
-                except Exception as e: # Transaction Failed, rollback everything
-                    set_balance(ctx.author, userBal)
-                    set_balance(targetMember, targetBal)
-                    log.error("Transaction Failed | %s -> %s ($%s) | Error: %s" % (ctx.author.name, targetMember.name, str(amount), str(e)))    
-                    await ctx.send("Transaction Failed. Please try again later.")
+            try: # Begin Transaction
+                add_balance(ctx.author, -float(amount))
+                add_balance(targetMember, float(amount))
+                await ctx.send("Transaction Complete!")
+            except Exception as e: # Transaction Failed, rollback everything
+                set_balance(ctx.author, userBal)
+                set_balance(targetMember, targetBal)
+                log.error("Transaction Failed | %s -> %s ($%s) | Error: %s" % (ctx.author.name, targetMember.name, str(amount), str(e)))    
+                await ctx.send("Transaction Failed. Please try again later.")
 
 def setup(client):
-    client.add_cog(Pay(client))
+    client.add_command(pay)

--- a/commands/ping.py
+++ b/commands/ping.py
@@ -10,23 +10,19 @@ from events.ready import up
 
 from pythonping import ping
 
-class Ping(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command()
-    async def ping(self, ctx):
-        pongStr = "Pong!"
-        pongEmbed = discord.Embed(title="Pong!", description="_Pinging..._", color=colour.secondary)
-        start = time.time() * 1000
-        msg = await ctx.message.channel.send(embed=pongEmbed)
-        end = time.time() * 1000
-        response_list = ping('gateway.discord.gg', size=56, count=5)
-        gateway_ping = response_list.rtt_avg_ms
-        pongEmbed = discord.Embed(title="Pong!", description="Gateway: `%sms`\nRest: `%sms`" % (str(gateway_ping), str(int(round(end-start, 0)))), color=colour.secondary)
-        pongEmbed.set_footer(text="Online For: " + str(time_phaser(int(time.time()-self.client.up))))
-        await msg.edit(embed=pongEmbed)
+@commands.command()
+async def ping(ctx):
+    pongStr = "Pong!"
+    pongEmbed = discord.Embed(title="Pong!", description="_Pinging..._", color=colour.secondary)
+    start = time.time() * 1000
+    msg = await ctx.message.channel.send(embed=pongEmbed)
+    end = time.time() * 1000
+    response_list = ping('gateway.discord.gg', size=56, count=5)
+    gateway_ping = response_list.rtt_avg_ms
+    pongEmbed = discord.Embed(title="Pong!", description="Gateway: `%sms`\nRest: `%sms`" % (str(gateway_ping), str(int(round(end-start, 0)))), color=colour.secondary)
+    pongEmbed.set_footer(text="Online For: " + str(time_phaser(int(time.time()-ctx.bot.up))))
+    await msg.edit(embed=pongEmbed)
 
 def setup(client):
-    client.add_cog(Ping(client))
+    client.add_command(ping)

--- a/commands/playing.py
+++ b/commands/playing.py
@@ -7,36 +7,32 @@ import utils.database as sql
 import utils.sinusbot as sinusbot
 from utils.helpers import *
 
-class Playing(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command()
-    async def playing(self, ctx):
-        song = sinusbot.playing()
-        if song == None:
-            print("wtf")
-        version = song[2]
-        if song[1] == "0:00":
-            duration = "Unknown"
-        else:
-            duration = str(song[1])
-        if song == None:
-            song = ["_An error occurred fetching playing status. Please try again later._", "0:00"]
-        if song[3]:
-            embed = discord.Embed(description=song[0], color=0x940060)
-            embed.set_author(name="One World Radio | Currently Playing", icon_url="https://i.foggyio.uk/tml.png")
-            embed.set_thumbnail(url="https://i.foggyio.uk/one_world_radio.png")
-        else:
-            embed = discord.Embed(description=song[0], color=colour.reds)
-            embed.set_author(name="Currently Playing", icon_url="https://i.foggyio.uk/playing.png")
-            embed.set_thumbnail(url="https://i.foggyio.uk/SinusBot.png")
-        if not duration == "Unknown":
-            embed.set_footer(text="Duration: " + duration + " | SinusBot " + version)
-        else:
-            embed.set_footer(text="SinusBot " + version)
-        await ctx.send(embed=embed)
+@commands.command()
+async def playing(ctx):
+    song = sinusbot.playing()
+    if song == None:
+        print("wtf")
+    version = song[2]
+    if song[1] == "0:00":
+        duration = "Unknown"
+    else:
+        duration = str(song[1])
+    if song == None:
+        song = ["_An error occurred fetching playing status. Please try again later._", "0:00"]
+    if song[3]:
+        embed = discord.Embed(description=song[0], color=0x940060)
+        embed.set_author(name="One World Radio | Currently Playing", icon_url="https://i.foggyio.uk/tml.png")
+        embed.set_thumbnail(url="https://i.foggyio.uk/one_world_radio.png")
+    else:
+        embed = discord.Embed(description=song[0], color=colour.reds)
+        embed.set_author(name="Currently Playing", icon_url="https://i.foggyio.uk/playing.png")
+        embed.set_thumbnail(url="https://i.foggyio.uk/SinusBot.png")
+    if not duration == "Unknown":
+        embed.set_footer(text="Duration: " + duration + " | SinusBot " + version)
+    else:
+        embed.set_footer(text="SinusBot " + version)
+    await ctx.send(embed=embed)
 
 def setup(client):
-    client.add_cog(Playing(client))
+    client.add_command(playing)

--- a/commands/poll.py
+++ b/commands/poll.py
@@ -6,53 +6,49 @@ import utils.values as value
 import utils.database as sql
 from utils.helpers import *
 
-class Poll(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command()
-    async def poll(self, ctx):
-        if "Supporter" in [role.name for role in ctx.author.roles] or "Moderator" in [role.name for role in ctx.author.roles] or "Manager" in [role.name for role in ctx.author.roles]:
-            if not self.client.polls:
-                args = ctx.message.content.split(" ")
-                time = args[1]
-                time_seconds = int(args[1])*60
-                options = " ".join(args[2:]).split("|")[1:]
-                question = " ".join(args[2:]).split("|")[0]
-                i = 1
-                options_string = ""
-                for option in options:
-                    options_string += "**%s)** %s\n" % (str(i), str(option))
-                    i += 1
-                votes_init = []
-                for count in range(1, i):
-                    votes_init.append(0)
-                embed=discord.Embed(description="%s \n\n %s\nVote using **!vote <option>**\n\nPoll Closes In **%s Minutes** " % (question, options_string, time), colour=colour.primary)
-                embed.set_author(name="Poll")
-                await ctx.send(embed=embed)
-                self.client.polls = True
-                self.client.polls_options = options
-                self.client.polls_votes = votes_init
-                await asyncio.sleep(time_seconds)
-                results_string = ""
-                i = 1
-                for option in options:
-                    results_string += "**%s)** %s - **%s Votes**\n" % (str(i), option, str(self.client.polls_votes[i-1]))
-                    i = i+1
-                embed=discord.Embed(description="Results are as follows:\n\n%s\n%s" % (question, results_string), colour=colour.primary)
-                embed.set_author(name="Poll Results")
-                await ctx.send(embed=embed)
-                self.client.polls_votes.clear()
-                self.client.polls_options.clear()
-                self.client.polls_enteries.clear()
-                self.client.polls = False
-            else:
-                embed=discord.Embed(description="A Poll is already in progress. Please wait until the current poll has ended.", colour=colour.reds)
-                embed.set_author(name="Error")
-                await ctx.send(embed=embed)
+@commands.command()
+async def poll(ctx):
+    if "Supporter" in [role.name for role in ctx.author.roles] or "Moderator" in [role.name for role in ctx.author.roles] or "Manager" in [role.name for role in ctx.author.roles]:
+        if not ctx.bot.polls:
+            args = ctx.message.content.split(" ")
+            time = args[1]
+            time_seconds = int(args[1])*60
+            options = " ".join(args[2:]).split("|")[1:]
+            question = " ".join(args[2:]).split("|")[0]
+            i = 1
+            options_string = ""
+            for option in options:
+                options_string += "**%s)** %s\n" % (str(i), str(option))
+                i += 1
+            votes_init = []
+            for count in range(1, i):
+                votes_init.append(0)
+            embed=discord.Embed(description="%s \n\n %s\nVote using **!vote <option>**\n\nPoll Closes In **%s Minutes** " % (question, options_string, time), colour=colour.primary)
+            embed.set_author(name="Poll")
+            await ctx.send(embed=embed)
+            ctx.bot.polls = True
+            ctx.bot.polls_options = options
+            ctx.bot.polls_votes = votes_init
+            await asyncio.sleep(time_seconds)
+            results_string = ""
+            i = 1
+            for option in options:
+                results_string += "**%s)** %s - **%s Votes**\n" % (str(i), option, str(ctx.bot.polls_votes[i-1]))
+                i = i+1
+            embed=discord.Embed(description="Results are as follows:\n\n%s\n%s" % (question, results_string), colour=colour.primary)
+            embed.set_author(name="Poll Results")
+            await ctx.send(embed=embed)
+            ctx.bot.polls_votes.clear()
+            ctx.bot.polls_options.clear()
+            ctx.bot.polls_enteries.clear()
+            ctx.bot.polls = False
         else:
-            await ctx.send("**Insufficient Permissions:** This command requires permission rank `SUPPORTER`")
+            embed=discord.Embed(description="A Poll is already in progress. Please wait until the current poll has ended.", colour=colour.reds)
+            embed.set_author(name="Error")
+            await ctx.send(embed=embed)
+    else:
+        await ctx.send("**Insufficient Permissions:** This command requires permission rank `SUPPORTER`")
 
 def setup(client):
-    client.add_cog(Poll(client))
+    client.add_command(poll)

--- a/commands/profile.py
+++ b/commands/profile.py
@@ -6,83 +6,79 @@ import utils.values as value
 import utils.database as sql
 from utils.helpers import *
 
-class Profile(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
+@commands.command()
+async def profile(ctx, user : discord.Member = None):
+    message = ctx.message
+    if user is None:
+        user = ctx.author
 
-    @commands.command()
-    async def profile(self, ctx, user : discord.Member = None):
-        message = ctx.message
-        if user is None:
-            user = ctx.author
+    profile = get_profile(user.id)
 
-        profile = get_profile(user.id)
+    if "Supporter" in [role.name for role in user.roles]:
+        em = discord.Embed(title=user.name, colour=0xf231ff)
+    else:
+        em = discord.Embed(title=user.name, colour=eval(profile[4]))
 
-        if "Supporter" in [role.name for role in user.roles]:
-            em = discord.Embed(title=user.name, colour=0xf231ff)
+    exps = sql.db_query("SELECT UserID FROM Members WHERE NOT UserID = 472063067014823938 AND NOT UserID = 1 ORDER BY expTotal DESC")
+    lpos = 1
+    for userl in exps:
+        userlOb = discord.utils.get(ctx.guild.members, id=userl[0])
+        if userlOb is None or userlOb.bot:
+            pass
+        elif not userl[0] == user.id:
+            lpos = lpos + 1
         else:
-            em = discord.Embed(title=user.name, colour=eval(profile[4]))
+            break
 
-        exps = sql.db_query("SELECT UserID FROM Members WHERE NOT UserID = 472063067014823938 AND NOT UserID = 1 ORDER BY expTotal DESC")
-        lpos = 1
-        for userl in exps:
-            userlOb = discord.utils.get(ctx.guild.members, id=userl[0])
-            if userlOb is None or userlOb.bot:
-                pass
-            elif not userl[0] == user.id:
-                lpos = lpos + 1
-            else:
-                break
+    activity = sql.db_query("SELECT UserID FROM Members WHERE NOT UserID = 472063067014823938 AND NOT UserID = 1 ORDER BY weeklyActivity DESC")
+    apos = 1
+    for usera in activity:
+        if not usera[0] == user.id:
+            apos = apos + 1
+        else:
+            break
 
-        activity = sql.db_query("SELECT UserID FROM Members WHERE NOT UserID = 472063067014823938 AND NOT UserID = 1 ORDER BY weeklyActivity DESC")
-        apos = 1
-        for usera in activity:
-            if not usera[0] == user.id:
-                apos = apos + 1
-            else:
-                break
-
-        bals = sql.db_query("SELECT UserID FROM Members WHERE NOT UserID = 472063067014823938 AND NOT UserID = 1 ORDER BY Balance DESC")
-        bpos = 1
-        for userb in bals:
-            if not userb[0] == user.id:
-                bpos = bpos + 1
-            else:
-                break
+    bals = sql.db_query("SELECT UserID FROM Members WHERE NOT UserID = 472063067014823938 AND NOT UserID = 1 ORDER BY Balance DESC")
+    bpos = 1
+    for userb in bals:
+        if not userb[0] == user.id:
+            bpos = bpos + 1
+        else:
+            break
 
 
-        rank = get_rank(user)
-        cookies_no = sql.db_query("SELECT cookiesReceived FROM Members WHERE UserID = %s" % (str(user.id)))[0][0]
-        em.set_author(name=rank[0], icon_url=rank[1])
+    rank = get_rank(user)
+    cookies_no = sql.db_query("SELECT cookiesReceived FROM Members WHERE UserID = %s" % (str(user.id)))[0][0]
+    em.set_author(name=rank[0], icon_url=rank[1])
 
-        badges = profile[3]
+    badges = profile[3]
 
-        exp = profile[6]
-        expCost = 5 * (profile[1]*profile[1]) + 50 * profile[1] + 100
+    exp = profile[6]
+    expCost = 5 * (profile[1]*profile[1]) + 50 * profile[1] + 100
 
-        preLevelTotal = profile[2] - exp
-        nextRequiredAmount = preLevelTotal + expCost
+    preLevelTotal = profile[2] - exp
+    nextRequiredAmount = preLevelTotal + expCost
 
-        cosmetics_all = sql.db_query("SELECT cosmetic_id FROM cosmetics")
-        cosmetics_total = len(cosmetics_all)
-        inventory = eval(sql.db_query("SELECT cosmetics FROM Members WHERE UserID = %s" % (str(user.id)))[0][0])
-        inventory_size = len(inventory)
+    cosmetics_all = sql.db_query("SELECT cosmetic_id FROM cosmetics")
+    cosmetics_total = len(cosmetics_all)
+    inventory = eval(sql.db_query("SELECT cosmetics FROM Members WHERE UserID = %s" % (str(user.id)))[0][0])
+    inventory_size = len(inventory)
 
-        em.add_field(name=badges, value="_ _ _ _ ")
-        em.set_thumbnail(url=user.avatar_url)
-        em.add_field(name="_ _ _ _", value="_ _ _ _", inline=False)
-        em.add_field(name="Level", value=str(profile[1])+ " [**#" + str(lpos) + "**]")
-        em.add_field(name="Experience", value=str(profile[2])+ "/" + str(nextRequiredAmount))
-        em.add_field(name="Member Since", value=str(user.joined_at)[0:19])
+    em.add_field(name=badges, value="_ _ _ _ ")
+    em.set_thumbnail(url=user.avatar_url)
+    em.add_field(name="_ _ _ _", value="_ _ _ _", inline=False)
+    em.add_field(name="Level", value=str(profile[1])+ " [**#" + str(lpos) + "**]")
+    em.add_field(name="Experience", value=str(profile[2])+ "/" + str(nextRequiredAmount))
+    em.add_field(name="Member Since", value=str(user.joined_at)[0:19])
 
-        em.add_field(name="Balance", value="$"+str(balance_formatter(round(float(profile[0]),2 ))))
-        em.add_field(name="Cookies Received", value=str(cookies_no))
-        em.add_field(name="Cosmetics Unlocked", value="%s/%s" % (str(inventory_size), str(cosmetics_total)))
-        if not profile[5] is None:
-            em.set_footer(text=""+profile[5])
+    em.add_field(name="Balance", value="$"+str(balance_formatter(round(float(profile[0]),2 ))))
+    em.add_field(name="Cookies Received", value=str(cookies_no))
+    em.add_field(name="Cosmetics Unlocked", value="%s/%s" % (str(inventory_size), str(cosmetics_total)))
+    if not profile[5] is None:
+        em.set_footer(text=""+profile[5])
 
-        await message.channel.send(embed=em)
+    await message.channel.send(embed=em)
 
 def setup(client):
-    client.add_cog(Profile(client))
+    client.add_command(profile)

--- a/commands/puppy.py
+++ b/commands/puppy.py
@@ -7,18 +7,14 @@ import utils.database as sql
 from utils.helpers import *
 import requests
 
-class Puppy(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command()
-    async def puppy(self, ctx):
-        imgUrl = requests.get('https://dog.ceo/api/breeds/image/random').json()['message']
-        em = discord.Embed(title="Puppy", image=imgUrl, colour=colour.secondary)
-        em.set_image(url=imgUrl)
-        await ctx.send(embed=em)
+@commands.command()
+async def puppy(ctx):
+    imgUrl = requests.get('https://dog.ceo/api/breeds/image/random').json()['message']
+    em = discord.Embed(title="Puppy", image=imgUrl, colour=colour.secondary)
+    em.set_image(url=imgUrl)
+    await ctx.send(embed=em)
 
 def setup(client):
-    client.add_cog(Puppy(client))
+    client.add_command(puppy)
     

--- a/commands/raffle.py
+++ b/commands/raffle.py
@@ -6,39 +6,35 @@ import utils.values as value
 import utils.database as sql
 from utils.helpers import *
 
-class Raffle(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command()
-    async def raffle(self, ctx):
-        if "Moderator" in [role.name for role in ctx.author.roles] or "Manager" in [role.name for role in ctx.author.roles]:
-            if not self.client.raffles:
-                args = ctx.message.content.split(" ")
-                item = " ".join(args[2:])
-                time = int(args[1])*60
-                em = discord.Embed(description="%s has started a raffle! Type `!enter` to be in with a chance to win `%s`!\n\n Raffle closes in `%s Minutes`" % (ctx.author.mention, item, str(args[1])), colour=0x00ff73)
-                em.set_author(name="Raffle")
-                await ctx.message.channel.send(embed=em)
-                self.client.raffles = True
-                await asyncio.sleep(time-30)
-                em = discord.Embed(description="The raffle ends in 30 seconds! Type `!enter` to be in with a chance to win `%s`!" % (item), colour=0x00ff73)
-                em.set_author(name="Raffle")
-                await ctx.send(embed=em)
-                await asyncio.sleep(30)
-                self.client.raffles = False
-                winner = random.choice(self.client.enteries)
-                em = discord.Embed(description="The raffle has ended! Congratulations to `%s` for winning `%s`!" % (winner, item), colour=0x00ff73)
-                em.set_author(name="Raffle Ended")
-                await ctx.message.channel.send(embed=em)
-                self.client.enteries.clear()
-            else:
-                embed=discord.Embed(description="A Raffle is already in progress. Please wait until the current raffle has ended.", colour=colour.reds)
-                em.set_author(name="Error")
-                await ctx.send(embed=embed)
+@commands.command()
+async def raffle(ctx):
+    if "Moderator" in [role.name for role in ctx.author.roles] or "Manager" in [role.name for role in ctx.author.roles]:
+        if not ctx.bot.raffles:
+            args = ctx.message.content.split(" ")
+            item = " ".join(args[2:])
+            time = int(args[1])*60
+            em = discord.Embed(description="%s has started a raffle! Type `!enter` to be in with a chance to win `%s`!\n\n Raffle closes in `%s Minutes`" % (ctx.author.mention, item, str(args[1])), colour=0x00ff73)
+            em.set_author(name="Raffle")
+            await ctx.message.channel.send(embed=em)
+            ctx.bot.raffles = True
+            await asyncio.sleep(time-30)
+            em = discord.Embed(description="The raffle ends in 30 seconds! Type `!enter` to be in with a chance to win `%s`!" % (item), colour=0x00ff73)
+            em.set_author(name="Raffle")
+            await ctx.send(embed=em)
+            await asyncio.sleep(30)
+            ctx.bot.raffles = False
+            winner = random.choice(ctx.bot.enteries)
+            em = discord.Embed(description="The raffle has ended! Congratulations to `%s` for winning `%s`!" % (winner, item), colour=0x00ff73)
+            em.set_author(name="Raffle Ended")
+            await ctx.message.channel.send(embed=em)
+            ctx.bot.enteries.clear()
         else:
-            await ctx.send("**Insufficient Permissions:** This command requires permission rank `MODERATOR`")
+            embed=discord.Embed(description="A Raffle is already in progress. Please wait until the current raffle has ended.", colour=colour.reds)
+            em.set_author(name="Error")
+            await ctx.send(embed=embed)
+    else:
+        await ctx.send("**Insufficient Permissions:** This command requires permission rank `MODERATOR`")
 
 def setup(client):
-    client.add_cog(Raffle(client))
+    client.add_command(raffle)

--- a/commands/ransack.py
+++ b/commands/ransack.py
@@ -6,16 +6,12 @@ import utils.values as value
 import utils.database as sql
 from utils.helpers import *
 
-class Ransack(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command()
-    async def ransack(self, ctx):
-        em = discord.Embed(description="Oak's words echoed... There's a time and place for everything, but not now.", colour=colour.reds)
-        em.set_author(name="Ransack")
-        await ctx.send(embed=em)
+@commands.command()
+async def ransack(ctx):
+    em = discord.Embed(description="Oak's words echoed... There's a time and place for everything, but not now.", colour=colour.reds)
+    em.set_author(name="Ransack")
+    await ctx.send(embed=em)
 
 def setup(client):
-    client.add_cog(Ransack(client))
+    client.add_command(ransack)

--- a/commands/shop.py
+++ b/commands/shop.py
@@ -7,16 +7,11 @@ import utils.database as sql
 from utils.helpers import *
 
 
-class Shop(commands.Cog):
-
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command()
-    async def shop(self, ctx):
-        args = ctx.message.content.split()
-        if len(args) == 1:
-            shop_string = """1) **Custom Tag** -  __$15.00__
+@commands.command()
+async def shop(ctx):
+    args = ctx.message.content.split()
+    if len(args) == 1:
+        shop_string = """1) **Custom Tag** -  __$15.00__
 A custom role for you, permanent, no hoist or color
 
 2) **Custom Profile Colour** -  __$10.00__
@@ -30,71 +25,71 @@ Help boost your level with this exp bonus
 
 5) **1 Crate** - __$1.00__
 Open the crate to see what's inside
-            """
-            shopEm = discord.Embed(description="List of Purchasable Items\n" +shop_string , color=colour.primary)
-            shopEm.set_author(name="Shop")
-            shopEm.add_field(name="How to use the shop", value="You can obtain balance through being the most active each week, once you have enough balance to purchase an item on the shop, type !shop buy <item> <quantity>", inline=False)
-            await ctx.send(embed=shopEm)
-        else:
-            if args[1].upper() == "BUY":
-                bal = fetch_balance(ctx.author)
-                if len(args) > 3:
-                    quantity = int(args[3])
+        """
+        shopEm = discord.Embed(description="List of Purchasable Items\n" +shop_string , color=colour.primary)
+        shopEm.set_author(name="Shop")
+        shopEm.add_field(name="How to use the shop", value="You can obtain balance through being the most active each week, once you have enough balance to purchase an item on the shop, type !shop buy <item> <quantity>", inline=False)
+        await ctx.send(embed=shopEm)
+    else:
+        if args[1].upper() == "BUY":
+            bal = fetch_balance(ctx.author)
+            if len(args) > 3:
+                quantity = int(args[3])
+            else:
+                quantity = 1
+            if args[2] == "1":
+                if bal >= 15.00:
+                    add_balance(ctx.author, -15.00)
+                    em = discord.Embed(description="Please contact a member of staff to request your tag!", color=colour.primary)
+                    em.set_author(name="Purchase Successful")
+                    await ctx.send(embed=em)
                 else:
-                    quantity = 1
-                if args[2] == "1":
-                    if bal >= 15.00:
-                        add_balance(ctx.author, -15.00)
-                        em = discord.Embed(description="Please contact a member of staff to request your tag!", color=colour.primary)
-                        em.set_author(name="Purchase Successful")
-                        await ctx.send(embed=em)
-                    else:
-                        await discord_error("Insufficent funds", ctx)
-                elif args[2] == "2":
-                    if bal >= 10.00:
-                        add_balance(ctx.author, -10.00)
-                        em = discord.Embed(description="Please contact a member of staff to request your profile colour!", color=colour.primary)
-                        em.set_author(name="Purchase Successful")
-                        await ctx.send(embed=em)
-                    else:
-                         await discord_error("Insufficent funds", ctx)
-
-                elif args[2] == "3":
-                    if bal >= 5.00:
-                        add_balance(ctx.author, -5.00)
-                        em = discord.Embed(description="Please contact a member of staff to request your role!", color=colour.primary)
-                        em.set_author(name="Purchase Successful")
-                        await ctx.send(embed=em)
-                    else:
-                        await discord_error("Insufficent funds", ctx)
-                elif args[2] == "4":
-                    if bal >= 2.50*float(quantity):
-                        add_balance(ctx.author, -2.50*float(quantity))
-                        em = discord.Embed(description="You have been given **%s** exp!" % (str(1000*quantity)), color=colour.primary)
-                        em.set_author(name="Purchase Successful")
-                        await ctx.send(embed=em)
-                        add_exp(ctx.author.id, 1000*quantity)
-                        await check_level_up(ctx.author.id, ctx.guild, ctx.channel)
-                    else:
-                        await discord_error("Insufficent funds", ctx)
-
-                elif args[2] == "5":
-                    if bal >= 1.00*float(quantity):
-                        crates_no = sql.db_query("SELECT crates FROM Members WHERE UserID = %s" % (str(ctx.author.id)))[0][0]
-                        if crates_no + quantity > 15:
-                           await discord_error("You cannot have more than 15 crates in your inventory", ctx)
-                        else:
-                            add_balance(ctx.author, -1.00*float(quantity))
-                            em = discord.Embed(description="You have been given **%s** crate(s)!" % (str(1*quantity)), color=colour.primary)
-                            em.set_author(name="Purchase Successful")
-                            await ctx.send(embed=em)
-                            crates_no = crates_no + 1*quantity
-                            sql.execute_query("UPDATE Members SET crates = %s WHERE UserID = %s" % (str(crates_no), str(ctx.author.id)))
-                    else:
-                        await discord_error("Insufficent funds", ctx)
+                    await discord_error("Insufficent funds", ctx)
+            elif args[2] == "2":
+                if bal >= 10.00:
+                    add_balance(ctx.author, -10.00)
+                    em = discord.Embed(description="Please contact a member of staff to request your profile colour!", color=colour.primary)
+                    em.set_author(name="Purchase Successful")
+                    await ctx.send(embed=em)
                 else:
-                    await discord_error("Invalid Item! Use `!shop` to view list of items", ctx)
+                    await discord_error("Insufficent funds", ctx)
+
+            elif args[2] == "3":
+                if bal >= 5.00:
+                    add_balance(ctx.author, -5.00)
+                    em = discord.Embed(description="Please contact a member of staff to request your role!", color=colour.primary)
+                    em.set_author(name="Purchase Successful")
+                    await ctx.send(embed=em)
+                else:
+                    await discord_error("Insufficent funds", ctx)
+            elif args[2] == "4":
+                if bal >= 2.50*float(quantity):
+                    add_balance(ctx.author, -2.50*float(quantity))
+                    em = discord.Embed(description="You have been given **%s** exp!" % (str(1000*quantity)), color=colour.primary)
+                    em.set_author(name="Purchase Successful")
+                    await ctx.send(embed=em)
+                    add_exp(ctx.author.id, 1000*quantity)
+                    await check_level_up(ctx.author.id, ctx.guild, ctx.channel)
+                else:
+                    await discord_error("Insufficent funds", ctx)
+
+            elif args[2] == "5":
+                if bal >= 1.00*float(quantity):
+                    crates_no = sql.db_query("SELECT crates FROM Members WHERE UserID = %s" % (str(ctx.author.id)))[0][0]
+                    if crates_no + quantity > 15:
+                        await discord_error("You cannot have more than 15 crates in your inventory", ctx)
+                    else:
+                        add_balance(ctx.author, -1.00*float(quantity))
+                        em = discord.Embed(description="You have been given **%s** crate(s)!" % (str(1*quantity)), color=colour.primary)
+                        em.set_author(name="Purchase Successful")
+                        await ctx.send(embed=em)
+                        crates_no = crates_no + 1*quantity
+                        sql.execute_query("UPDATE Members SET crates = %s WHERE UserID = %s" % (str(crates_no), str(ctx.author.id)))
+                else:
+                    await discord_error("Insufficent funds", ctx)
+            else:
+                await discord_error("Invalid Item! Use `!shop` to view list of items", ctx)
 
 
 def setup(client):
-    client.add_cog(Shop(client))
+    client.add_command(shop)

--- a/commands/streaks.py
+++ b/commands/streaks.py
@@ -8,14 +8,10 @@ import utils.database as sql
 import math
 from utils.helpers import *
 
-class Streaks(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command(aliases=["streaktop", "st", "stop"])
-    async def streaks(self, ctx):
-        await leaderboard_main(ctx, self=self)
+@commands.command(aliases=["streaktop", "st", "stop"])
+async def streaks(ctx):
+    await leaderboard_main(ctx)
 
 def generate_leaderboard_string(guild, page=1):
     leaderboard_2d_array = sql.db_query("SELECT UserID, dailyRewardStreak FROM Members WHERE NOT UserID = 1 ORDER BY dailyRewardStreak DESC")
@@ -37,7 +33,7 @@ def generate_leaderboard_string(guild, page=1):
             break
     return leaderboard_string
 
-async def leaderboard_main(ctx, page=1, leaderboard_message_object=None, self=None):
+async def leaderboard_main(ctx, page=1, leaderboard_message_object=None):
     max_pages = math.ceil((len(ctx.guild.members)-2)/10)
     leaderboard_string = generate_leaderboard_string(ctx.guild, page)
     embed = discord.Embed(description=leaderboard_string, color=colour.primary)
@@ -54,22 +50,22 @@ async def leaderboard_main(ctx, page=1, leaderboard_message_object=None, self=No
         return user == ctx.author and (str(reaction.emoji) == "◀" or str(reaction.emoji) == "▶")
 
     try:
-        reaction, user = await self.client.wait_for('reaction_add', timeout=30.0, check=check)
+        reaction, user = await ctx.bot.wait_for('reaction_add', timeout=30.0, check=check)
     except asyncio.TimeoutError:
         await leaderboard_message_object.clear_reactions()
     else:
         await reaction.remove(user)
         if str(reaction.emoji) == "◀":
             if not page == 1:
-                await leaderboard_main(ctx, page-1, leaderboard_message_object, self=self)
+                await leaderboard_main(ctx, page-1, leaderboard_message_object)
             else:
-                await leaderboard_main(ctx, page, leaderboard_message_object, self=self)
+                await leaderboard_main(ctx, page, leaderboard_message_object)
 
         elif str(reaction.emoji) == "▶":
             if not page+1 > max_pages:
-                await leaderboard_main(ctx, page+1, leaderboard_message_object, self=self)
+                await leaderboard_main(ctx, page+1, leaderboard_message_object)
             else:
-                await leaderboard_main(ctx, page, leaderboard_message_object, self=self)
+                await leaderboard_main(ctx, page, leaderboard_message_object)
 
 def setup(client):
-    client.add_cog(Streaks(client))
+    client.add_command(streaks)

--- a/commands/tag.py
+++ b/commands/tag.py
@@ -6,61 +6,57 @@ import utils.values as value
 import utils.database as sql
 from utils.helpers import *
 
-class Tag(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command()
-    async def tag(self, ctx):
-        args = ctx.message.content.split()
-        if args[1].upper() == "CREATE":
-            if get_profile(ctx.author.id)[1] >= 30 or "Moderator" in [role.name for role in ctx.message.author.roles] or "Manager" in [role.name for role in ctx.message.author.roles]:
-                tagContent = " ".join(args[3:]).replace("'", "''")
-                print(tagContent)
-                tagSubmitter = str(ctx.message.author)
-                tagName = args[2]
-                try:
-                    sql.execute_query("INSERT INTO tags (name, content, submittedBy) VALUES ('%s', '%s', '%s')" % (tagName.replace("'", "''"), tagContent.replace("'", "''"), tagSubmitter.replace("'", "''")))
-                    await ctx.send("Tag successfully created")
-                except:
-                    await ctx.send("A tag already exists with that name")
-            else:
-                await ctx.send("You are not allowed to create tags yet!")
-        elif args[1].upper() == "CREATE_IMG":
-            if get_profile(ctx.author.id)[1] >= 30 or "Moderator" in [role.name for role in ctx.message.author.roles] or "Manager" in [role.name for role in ctx.message.author.roles]:
-                tagContent = " ".join(args[3:]).replace("'", "''")
-                tagSubmitter = str(ctx.message.author)
-                tagName = args[2]
-                try:
-                    sql.execute_query("INSERT INTO tags (name, content, submittedBy, isImage) VALUES ('%s', '%s', '%s', 1)" % (tagName.replace("'", "''"), tagContent.replace("'", "''"), tagSubmitter.replace("'", "''")))
-                    await ctx.send("Tag successfully created")
-                except:
-                    await ctx.send("A tag already exists with that name")
-            else:
-                await ctx.send("You are not allowed to create tags yet!")
-        elif args[1].upper() == "DELETE":
-            if "Moderator" in [role.name for role in ctx.message.author.roles] or "Manager" in [role.name for role in ctx.message.author.roles]:
-                tagName = args[2]
-                tag = sql.db_query("SELECT name FROM tags WHERE name = '%s'" % (tagName.replace("'", "''")))
-                if len(tag) == 0: # tag does not exists
-                    await ctx.send("There is no tag with that name")
-                else:
-                    sql.execute_query("DELETE FROM tags WHERE name = '%s'" % (tagName.replace("'", "''")))
-                    await ctx.send("Tag has been successfully deleted")
+@commands.command()
+async def tag(ctx):
+    args = ctx.message.content.split()
+    if args[1].upper() == "CREATE":
+        if get_profile(ctx.author.id)[1] >= 30 or "Moderator" in [role.name for role in ctx.message.author.roles] or "Manager" in [role.name for role in ctx.message.author.roles]:
+            tagContent = " ".join(args[3:]).replace("'", "''")
+            print(tagContent)
+            tagSubmitter = str(ctx.message.author)
+            tagName = args[2]
+            try:
+                sql.execute_query("INSERT INTO tags (name, content, submittedBy) VALUES ('%s', '%s', '%s')" % (tagName.replace("'", "''"), tagContent.replace("'", "''"), tagSubmitter.replace("'", "''")))
+                await ctx.send("Tag successfully created")
+            except:
+                await ctx.send("A tag already exists with that name")
         else:
-            tagName = args[1]
-            tag = sql.db_query("SELECT name, content, submittedBy, isImage FROM tags WHERE name = '%s'" % (tagName.replace("'", "''")))
-            if not len(tag) == 0:
-                if tag[0][3] == 1:
-                    embed = discord.Embed(title=tag[0][0], color=colour.secondary)
-                    embed.set_image(url=tag[0][1])
-                else:
-                    embed = discord.Embed(title=tag[0][0], description=tag[0][1], color=colour.secondary)
-                embed.set_footer(text="Submitted By: " + tag[0][2])
-                await ctx.send(embed=embed)
+            await ctx.send("You are not allowed to create tags yet!")
+    elif args[1].upper() == "CREATE_IMG":
+        if get_profile(ctx.author.id)[1] >= 30 or "Moderator" in [role.name for role in ctx.message.author.roles] or "Manager" in [role.name for role in ctx.message.author.roles]:
+            tagContent = " ".join(args[3:]).replace("'", "''")
+            tagSubmitter = str(ctx.message.author)
+            tagName = args[2]
+            try:
+                sql.execute_query("INSERT INTO tags (name, content, submittedBy, isImage) VALUES ('%s', '%s', '%s', 1)" % (tagName.replace("'", "''"), tagContent.replace("'", "''"), tagSubmitter.replace("'", "''")))
+                await ctx.send("Tag successfully created")
+            except:
+                await ctx.send("A tag already exists with that name")
+        else:
+            await ctx.send("You are not allowed to create tags yet!")
+    elif args[1].upper() == "DELETE":
+        if "Moderator" in [role.name for role in ctx.message.author.roles] or "Manager" in [role.name for role in ctx.message.author.roles]:
+            tagName = args[2]
+            tag = sql.db_query("SELECT name FROM tags WHERE name = '%s'" % (tagName.replace("'", "''")))
+            if len(tag) == 0: # tag does not exists
+                await ctx.send("There is no tag with that name")
             else:
-                await ctx.send("That tag does not exist")
+                sql.execute_query("DELETE FROM tags WHERE name = '%s'" % (tagName.replace("'", "''")))
+                await ctx.send("Tag has been successfully deleted")
+    else:
+        tagName = args[1]
+        tag = sql.db_query("SELECT name, content, submittedBy, isImage FROM tags WHERE name = '%s'" % (tagName.replace("'", "''")))
+        if not len(tag) == 0:
+            if tag[0][3] == 1:
+                embed = discord.Embed(title=tag[0][0], color=colour.secondary)
+                embed.set_image(url=tag[0][1])
+            else:
+                embed = discord.Embed(title=tag[0][0], description=tag[0][1], color=colour.secondary)
+            embed.set_footer(text="Submitted By: " + tag[0][2])
+            await ctx.send(embed=embed)
+        else:
+            await ctx.send("That tag does not exist")
 
 def setup(client):
-    client.add_cog(Tag(client))
+    client.add_command(tag)

--- a/commands/weekly.py
+++ b/commands/weekly.py
@@ -6,41 +6,13 @@ import utils.values as value
 import utils.database as sql
 from utils.helpers import *
 
-class Profile(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
-
-    @commands.command()
-    async def weekly(self, ctx):
-        args = ctx.message.content.split(" ")
-        showDetails = False
-        if len(args) >= 2 and ("Moderator" in [role.name for role in ctx.author.roles] or "Manager" in [role.name for role in ctx.author.roles]):
-            if args[1].upper() == "DETAILS":
-                activity = sql.db_query("SELECT UserID, weeklyActivity FROM Members WHERE NOT UserID = 472063067014823938 AND NOT UserID = 1 AND NOT UserID = 568905827952361490 ORDER BY weeklyActivity DESC")
-                count = 1
-                index = 0
-                server_total = 0
-                for entry in activity:
-                    server_total += entry[1]
-                lbString = "Server Total: **" + str(server_total) + " Points**\n\n"
-
-                while count < 6:
-                    user = discord.utils.get(ctx.guild.members, id=activity[index][0])
-                    if not user == None:
-                        lbString += "**" + str(count) + ")** <@" + str(activity[index][0]) + "> - **" + str(balance_formatter(activity[index][1])) +"** Points\n"
-                        count += 1
-                    index += 1
-                embed = discord.Embed(description=lbString, color=colour.primary)
-                embed.set_author(name="Weekly Activity Leaderboard")
-                embed.set_thumbnail(url="https://i.foggyio.uk/varsity_discord.png")
-                await ctx.send(embed=embed)
-            elif args[1].upper() == "RESET":
-                if "Manager" in [role.name for role in ctx.author.roles]:
-                    sql.execute_query("UPDATE Members SET weeklyActivity=0")
-                    await ctx.send("Reset Weekly Activity Stats")
-                    return
-        else:
+@commands.command()
+async def weekly(ctx):
+    args = ctx.message.content.split(" ")
+    showDetails = False
+    if len(args) >= 2 and ("Moderator" in [role.name for role in ctx.author.roles] or "Manager" in [role.name for role in ctx.author.roles]):
+        if args[1].upper() == "DETAILS":
             activity = sql.db_query("SELECT UserID, weeklyActivity FROM Members WHERE NOT UserID = 472063067014823938 AND NOT UserID = 1 AND NOT UserID = 568905827952361490 ORDER BY weeklyActivity DESC")
             count = 1
             index = 0
@@ -48,31 +20,55 @@ class Profile(commands.Cog):
             for entry in activity:
                 server_total += entry[1]
             lbString = "Server Total: **" + str(server_total) + " Points**\n\n"
+
             while count < 6:
                 user = discord.utils.get(ctx.guild.members, id=activity[index][0])
                 if not user == None:
-                    lbString += "**" + str(count) + ")** <@" + str(activity[index][0]) + ">\n"
+                    lbString += "**" + str(count) + ")** <@" + str(activity[index][0]) + "> - **" + str(balance_formatter(activity[index][1])) +"** Points\n"
                     count += 1
                 index += 1
-
-            not_found = True
-            i = 1
-            index2 = 0
-            while not_found:
-                user = discord.utils.get(ctx.guild.members, id=activity[index2][0])
-                if not user == None:
-                    if activity[index2][0] == ctx.author.id:
-                        not_found = False
-                        if i >= 6:
-                            lbString += "\n**" + str(i) + ")** <@" + str(activity[index2][0]) + ">\n"
-                    i += 1
-                index2 += 1
-
             embed = discord.Embed(description=lbString, color=colour.primary)
             embed.set_author(name="Weekly Activity Leaderboard")
             embed.set_thumbnail(url="https://i.foggyio.uk/varsity_discord.png")
             await ctx.send(embed=embed)
+        elif args[1].upper() == "RESET":
+            if "Manager" in [role.name for role in ctx.author.roles]:
+                sql.execute_query("UPDATE Members SET weeklyActivity=0")
+                await ctx.send("Reset Weekly Activity Stats")
+                return
+    else:
+        activity = sql.db_query("SELECT UserID, weeklyActivity FROM Members WHERE NOT UserID = 472063067014823938 AND NOT UserID = 1 AND NOT UserID = 568905827952361490 ORDER BY weeklyActivity DESC")
+        count = 1
+        index = 0
+        server_total = 0
+        for entry in activity:
+            server_total += entry[1]
+        lbString = "Server Total: **" + str(server_total) + " Points**\n\n"
+        while count < 6:
+            user = discord.utils.get(ctx.guild.members, id=activity[index][0])
+            if not user == None:
+                lbString += "**" + str(count) + ")** <@" + str(activity[index][0]) + ">\n"
+                count += 1
+            index += 1
+
+        not_found = True
+        i = 1
+        index2 = 0
+        while not_found:
+            user = discord.utils.get(ctx.guild.members, id=activity[index2][0])
+            if not user == None:
+                if activity[index2][0] == ctx.author.id:
+                    not_found = False
+                    if i >= 6:
+                        lbString += "\n**" + str(i) + ")** <@" + str(activity[index2][0]) + ">\n"
+                i += 1
+            index2 += 1
+
+        embed = discord.Embed(description=lbString, color=colour.primary)
+        embed.set_author(name="Weekly Activity Leaderboard")
+        embed.set_thumbnail(url="https://i.foggyio.uk/varsity_discord.png")
+        await ctx.send(embed=embed)
 
 
 def setup(client):
-    client.add_cog(Profile(client))
+    client.add_command(weekly)

--- a/commands/xp.py
+++ b/commands/xp.py
@@ -6,28 +6,24 @@ import utils.values as value
 import utils.database as sql
 from utils.helpers import *
 
-class Xp(commands.Cog):
 
-    def __init__(self, client):
-        self.client = client
+@commands.command()
+async def xp(ctx, targetMember : discord.Member = None):
+    if "Manager" in [role.name for role in ctx.message.author.roles]:
+        args = ctx.message.content.split(" ")
+        member = targetMember
+        if args[2].upper() == "GIVE":
+            amount = args[3]
+            if int(amount) < 0:
+                await discord_error("Cannot give negative XP!", ctx)
+            else:
+                add_exp(member.id, int(amount))
+                em = discord.Embed(description=":ok_hand: Successfully given **%s** **%s EXP**!" % (member.name, amount), color=colour.primary)
+                em.set_author(name="Success")
+                await ctx.send(embed=em)
 
-    @commands.command()
-    async def xp(self, ctx, targetMember : discord.Member = None):
-        if "Manager" in [role.name for role in ctx.message.author.roles]:
-            args = ctx.message.content.split(" ")
-            member = targetMember
-            if args[2].upper() == "GIVE":
-                amount = args[3]
-                if int(amount) < 0:
-                    await discord_error("Cannot give negative XP!", ctx)
-                else:
-                    add_exp(member.id, int(amount))
-                    em = discord.Embed(description=":ok_hand: Successfully given **%s** **%s EXP**!" % (member.name, amount), color=colour.primary)
-                    em.set_author(name="Success")
-                    await ctx.send(embed=em)
-
-        else:
-            await discord_error("This command requires permission rank `MANAGER`", ctx)
+    else:
+        await discord_error("This command requires permission rank `MANAGER`", ctx)
 
 def setup(client):
-    client.add_cog(Xp(client))
+    client.add_command(xp)


### PR DESCRIPTION
*#422 was closed because I reset my changes, can't reopen it :/*

In short, this moves all commands out of their rather empty cogs.
Because simply put it, having one command per cog defeats the purpose of cogs.

Compared to the original way I suggested we do it, this is completely supported by the library!

This will most likely simplify the way you work with the bot, as you can work with the commands directly. Rather than finding them under the cog.

The way git shows the changes... is a little funky, but I just unindented it all mostly...

**Like earlier, this is completely untested**, as there are no set up instructions for how to define the token nor how to set up the database. Also for roles it's not clear how many and what they should be named. I might be missing even more stuff I need to do.